### PR TITLE
feat: Implement repertoire enable/disable functionality and update related components

### DIFF
--- a/packages/backend/src/controllers/repertoiresController.ts
+++ b/packages/backend/src/controllers/repertoiresController.ts
@@ -288,3 +288,34 @@ export async function deleteRepertoire(req: Request, res: Response, next: NextFu
     next(err);
   }
 }
+
+export async function disableRepertoire(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    const db = getDB();
+    const repertoire = await db
+      .collection("repertoires")
+      .findOneAndUpdate(
+        { _id: new ObjectId(id) },
+        { $set: { disabled: true } }
+      );
+    res.json(repertoire);
+  } catch (err) {
+    next(err);
+  }
+}
+export async function enableRepertoire(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    const db = getDB();
+    const repertoire = await db
+      .collection("repertoires")
+      .findOneAndUpdate(
+        { _id: new ObjectId(id) },
+        { $set: { disabled: false } }
+      );
+    res.json(repertoire);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/packages/backend/src/models/Path.ts
+++ b/packages/backend/src/models/Path.ts
@@ -6,6 +6,7 @@ export type Path =
 export type PathVariant = {
   _id: { $oid: string };
   repertoireId: string;
+  repertoireName: string;
   name: string;
   errors: number;
   lastDate: { $date: string };

--- a/packages/backend/src/models/Repertoire.ts
+++ b/packages/backend/src/models/Repertoire.ts
@@ -26,4 +26,5 @@ export interface Repertoire {
   moveNodes: MoveNode;
   orientation: "white" | "black";
   order: number;
+  disabled?: boolean;
 }

--- a/packages/backend/src/routes/repertoires.ts
+++ b/packages/backend/src/routes/repertoires.ts
@@ -12,7 +12,9 @@ import {
   updateRepertoire,
   updateRepertoireName,
   moveRepertoireOrderUp,
-  deleteRepertoire
+  deleteRepertoire,
+  disableRepertoire,
+  enableRepertoire
 } from "../controllers/repertoiresController";
 
 const router = Router();
@@ -23,11 +25,13 @@ router.get("/download", downloadRepertoires);
 router.get("/:id", getRepertoireById);
 router.get("/:id/download", downloadRepertoireById);
 router.post("/", createRepertoire);
-router.post(":/id/duplicate", duplicateRepertoire);
+router.post("/:id/duplicate", duplicateRepertoire);
 router.get("/:id/variantsInfo", getVariantsInfo);
 router.post("/:id/variantsInfo", postVariantsInfo);
 router.put("/:id", updateRepertoire);
 router.put("/:id/name", updateRepertoireName);
+router.put("/:id/enable", enableRepertoire);
+router.put("/:id/disable", disableRepertoire);
 router.patch("/:id/order/up", moveRepertoireOrderUp);
 router.delete("/:id", deleteRepertoire);
 

--- a/packages/common/src/types/Repertoire.ts
+++ b/packages/common/src/types/Repertoire.ts
@@ -7,6 +7,7 @@ export interface IRepertoire {
     moveNodes: IMoveNode;
     orientation: "white" | "black";
     order: number;
+    disabled?: boolean;
 }
 
 export interface IRepertoireDashboard  extends IRepertoire {

--- a/packages/frontend/src/hooks/useDashboard.tsx
+++ b/packages/frontend/src/hooks/useDashboard.tsx
@@ -3,7 +3,7 @@ import { getFullInfoRepertoires } from "../repository/repertoires/repertoires";
 import { IRepertoireDashboard } from "@chess-opening-master/common";
 
 export const useDashboard = () => {
-    const [dashbardoRepertoires, setDashboardRepertoires] = useState<IRepertoireDashboard[]>([]);
+    const [dashbardRepertoires, setDashboardRepertoires] = useState<IRepertoireDashboard[]>([]);
      
     useEffect(() => {
         getFullInfoRepertoires().then((data) => {
@@ -21,7 +21,7 @@ export const useDashboard = () => {
     }, []);
 
     return {
-        repertoires: dashbardoRepertoires,
+        repertoires: dashbardRepertoires,
         setRepertoires: setDashboardRepertoires,
         updateRepertoires
     };

--- a/packages/frontend/src/hooks/useDashboard.tsx
+++ b/packages/frontend/src/hooks/useDashboard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getFullInfoRepertoires } from "../repository/repertoires/repertoires";
 import { IRepertoireDashboard } from "@chess-opening-master/common";
 
@@ -9,12 +9,20 @@ export const useDashboard = () => {
         getFullInfoRepertoires().then((data) => {
             setDashboardRepertoires(data);
         });
-
     }, []);
 
+    const updateRepertoires = useCallback(async () => {
+        try {
+            const updatedRepertoires = await getFullInfoRepertoires();
+            setDashboardRepertoires(updatedRepertoires);
+        } catch (error) {
+            console.error("Failed to update repertoires:", error);
+        }
+    }, []);
 
     return {
         repertoires: dashbardoRepertoires,
-        setRepertoires: setDashboardRepertoires
+        setRepertoires: setDashboardRepertoires,
+        updateRepertoires
     };
 }

--- a/packages/frontend/src/models/Path.ts
+++ b/packages/frontend/src/models/Path.ts
@@ -6,4 +6,5 @@ export type Path = {
   lastDate?: { $date: string };
   lastSession?: string | null;
   repertoireId?: string;
+  repertoireName?: string;
 };

--- a/packages/frontend/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/packages/frontend/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -33,6 +33,7 @@ describe("DashboardPage", () => {
     jest.spyOn(useDashboardModule, "useDashboard").mockReturnValue({
       repertoires: mockRepertoires,
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
   });
 
@@ -121,6 +122,7 @@ describe("Openings section behaviors", () => {
     jest.spyOn(useDashboardModule, "useDashboard").mockReturnValue({
       repertoires: [makeRep("1", "Rep1", "white", "Ruy Lopez")],
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
     render(
       <BrowserRouter>
@@ -140,6 +142,7 @@ describe("Openings section behaviors", () => {
         makeRep("2", "Rep2", "black", "Ruy Lopez"),
       ],
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
     render(
       <BrowserRouter>
@@ -161,6 +164,7 @@ describe("Openings section behaviors", () => {
     jest.spyOn(useDashboardModule, "useDashboard").mockReturnValue({
       repertoires: [],
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
     render(
       <BrowserRouter>
@@ -179,6 +183,7 @@ describe("Openings section behaviors", () => {
         makeRep("2", "Rep2", "black", "Italian Game"),
       ],
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
     render(
       <BrowserRouter>
@@ -196,6 +201,7 @@ describe("Openings section behaviors", () => {
     jest.spyOn(useDashboardModule, "useDashboard").mockReturnValue({
       repertoires: [makeRep("1", "Rep1", "white", "Ruy Lopez")],
       setRepertoires: jest.fn(),
+      updateRepertoires: jest.fn().mockResolvedValue(undefined),
     });
     render(
       <BrowserRouter>

--- a/packages/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/packages/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -16,7 +16,7 @@ import { StudiesSection } from "./sections/StudiesSection";
 export const DashboardPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { repertoires } = useDashboard();
+  const { repertoires, updateRepertoires } = useDashboard();
   const [orientationFilter, setOrientationFilter] = useState<
     "all" | "white" | "black"
   >("all");
@@ -140,6 +140,7 @@ export const DashboardPage = () => {
             goToTrainRepertoire={goToTrainRepertoire}
             getTrainVariants={getTrainVariants}
             getTrainVariantInfo={getTrainVariantInfo}
+            updateRepertoires={updateRepertoires}
           />
         )}
         {selectedSection === 'openings' && (

--- a/packages/frontend/src/pages/DashboardPage/components/RepertoireCard.tsx
+++ b/packages/frontend/src/pages/DashboardPage/components/RepertoireCard.tsx
@@ -1,8 +1,10 @@
 import React from "react";
-import { EyeIcon, PlayIcon } from "@heroicons/react/24/solid";
+import { EyeIcon, PlayIcon, LockOpenIcon, LockClosedIcon } from "@heroicons/react/24/solid";
 import { VariantsProgressBar } from "../../../components/design/SelectTrainVariants/VariantsProgressBar";
 import { IRepertoireDashboard, TrainVariantInfo } from "@chess-opening-master/common";
 import { TrainVariant } from "../../../models/chess.models";
+import { useDialogContext } from "../../../contexts/DialogContext";
+import { disableRepertoire, enableRepertoire } from "../../../repository/repertoires/repertoires";
 
 interface RepertoireCardProps {
   repertoire: IRepertoireDashboard;
@@ -10,6 +12,7 @@ interface RepertoireCardProps {
   goToTrainRepertoire: (repertoire: IRepertoireDashboard) => void;
   getTrainVariants: (repertoire: IRepertoireDashboard) => TrainVariant[];
   getTrainVariantInfo: (trainInfo: TrainVariantInfo[]) => Record<string, TrainVariantInfo>;
+  updateRepertoires: () => void;
 }
 
 export const RepertoireCard: React.FC<RepertoireCardProps> = ({
@@ -18,30 +21,75 @@ export const RepertoireCard: React.FC<RepertoireCardProps> = ({
   goToTrainRepertoire,
   getTrainVariants,
   getTrainVariantInfo,
-}) => (
-  <li
-    className="p-3 sm:p-4 bg-gray-900 rounded-xl shadow-lg border border-gray-800 hover:shadow-2xl transition-shadow duration-300 flex flex-col justify-between ring-0 focus-within:ring-2 focus-within:ring-blue-400"
-  >
-    <h3 className="text-base sm:text-lg font-semibold mb-2 text-gray-100 text-center truncate">{repertoire.name}</h3>
-    <div className="flex space-x-2 mb-2 justify-center">
-      <button
-        className="flex items-center px-3 py-1 bg-gray-800 text-gray-100 rounded hover:bg-gray-700 transition-colors text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-        onClick={() => goToRepertoire(repertoire)}
-      >
-        <EyeIcon className="h-5 w-5 mr-1" />
-        View
-      </button>
-      <button
-        className="flex items-center px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-        onClick={() => goToTrainRepertoire(repertoire)}
-      >
-        <PlayIcon className="h-5 w-5 mr-1" />
-        Train
-      </button>
-    </div>
-    <VariantsProgressBar
-      variants={getTrainVariants(repertoire)}
-      variantInfo={getTrainVariantInfo(repertoire.variantsInfo)}
-    />
-  </li>
-);
+  updateRepertoires,
+}) => {
+  const { showConfirmDialog } = useDialogContext();
+  
+  const handleToggleDisable = () => {
+    if (repertoire.disabled) {
+      showConfirmDialog({
+        title: "Enable Repertoire",
+        contentText: `Are you sure you want to enable "${repertoire.name}"?`,
+        onConfirm: async () => {
+          await enableRepertoire(repertoire._id);
+          updateRepertoires();
+        },
+      });
+    } else {
+      showConfirmDialog({
+        title: "Disable Repertoire",
+        contentText: `Are you sure you want to disable "${repertoire.name}"? It will be visually marked as disabled in the dashboard.`,
+        onConfirm: async () => {
+          await disableRepertoire(repertoire._id);
+          updateRepertoires();
+        },
+      });
+    }
+  };
+
+  return (
+    <li
+      className={`p-3 sm:p-4 bg-gray-900 rounded-xl shadow-lg border ${
+        repertoire.disabled ? 'border-red-800 opacity-75' : 'border-gray-800'
+      } hover:shadow-2xl transition-shadow duration-300 flex flex-col justify-between ring-0 focus-within:ring-2 focus-within:ring-blue-400`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <h3 className={`text-base sm:text-lg font-semibold text-gray-100 truncate ${repertoire.disabled ? 'text-gray-400' : ''}`}>
+          {repertoire.name}
+          {repertoire.disabled && <span className="ml-2 text-xs text-red-400">(Disabled)</span>}
+        </h3>
+        <button
+          onClick={handleToggleDisable}
+          className={`p-1 rounded-full focus:outline-none focus:ring-2 ${
+            repertoire.disabled 
+              ? 'text-red-500 hover:text-red-400 focus:ring-red-400' 
+              : 'text-green-500 hover:text-green-400 focus:ring-green-400'
+          }`}
+          title={repertoire.disabled ? 'Enable repertoire' : 'Disable repertoire'}
+        >
+          {repertoire.disabled ? <LockClosedIcon className="h-4 w-4" /> : <LockOpenIcon className="h-4 w-4" />}
+        </button>
+      </div>
+      <div className="flex space-x-2 mb-2 justify-center">
+        <button
+          className="flex items-center px-3 py-1 bg-gray-800 text-gray-100 rounded hover:bg-gray-700 transition-colors text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+          onClick={() => goToRepertoire(repertoire)}
+        >
+          <EyeIcon className="h-5 w-5 mr-1" />
+          View
+        </button>
+        <button
+          className="flex items-center px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+          onClick={() => goToTrainRepertoire(repertoire)}
+        >
+          <PlayIcon className="h-5 w-5 mr-1" />
+          Train
+        </button>
+      </div>
+      <VariantsProgressBar
+        variants={getTrainVariants(repertoire)}
+        variantInfo={getTrainVariantInfo(repertoire.variantsInfo)}
+      />
+    </li>
+  );
+};

--- a/packages/frontend/src/pages/DashboardPage/sections/RepertoiresSection.tsx
+++ b/packages/frontend/src/pages/DashboardPage/sections/RepertoiresSection.tsx
@@ -14,6 +14,7 @@ interface RepertoiresSectionProps {
   goToTrainRepertoire: (repertoire: IRepertoireDashboard) => void;
   getTrainVariants: (repertoire: IRepertoireDashboard) => TrainVariant[];
   getTrainVariantInfo: (trainInfo: TrainVariantInfo[]) => Record<string, TrainVariantInfo>;
+  updateRepertoires: () => void;
 }
 
 export const RepertoiresSection: React.FC<RepertoiresSectionProps> = ({
@@ -26,6 +27,7 @@ export const RepertoiresSection: React.FC<RepertoiresSectionProps> = ({
   goToTrainRepertoire,
   getTrainVariants,
   getTrainVariantInfo,
+  updateRepertoires,
 }) => {
   const [statusFilter, setStatusFilter] = React.useState<'all' | 'errors' | 'successful' | 'new'>('all');
 
@@ -102,6 +104,7 @@ export const RepertoiresSection: React.FC<RepertoiresSectionProps> = ({
               goToTrainRepertoire={goToTrainRepertoire}
               getTrainVariants={getTrainVariants}
               getTrainVariantInfo={getTrainVariantInfo}
+              updateRepertoires={updateRepertoires}
             />
           ))}
         </ul>

--- a/packages/frontend/src/pages/PathPage/PathPage.tsx
+++ b/packages/frontend/src/pages/PathPage/PathPage.tsx
@@ -48,7 +48,7 @@ const PathPage: React.FC = () => {
                   {path.type === "variant" && (
                     <>
                       <BookOpenIcon className="h-7 w-7 sm:h-8 sm:w-8 text-blue-400 mb-2" />
-                      <div className="font-semibold text-base sm:text-lg text-blue-300 mb-1">Repertoire Variant to Review</div>
+                      <div className="font-semibold text-base sm:text-lg text-blue-300 mb-1">Repertoire to review: {path.repertoireName}</div>
                       <div className="text-sm sm:text-base text-gray-100 mb-1"><span className="font-medium">Name:</span> {path.name}</div>
                       <div className="text-gray-300 mb-1"><span className="font-medium">Errors:</span> {path.errors}</div>
                       <div className="text-gray-300 mb-1"><span className="font-medium">Last Reviewed:</span> {path.lastDate?.$date ? new Date(path.lastDate.$date).toLocaleString() : "Never"}</div>

--- a/packages/frontend/src/repository/repertoires/repertoires.tsx
+++ b/packages/frontend/src/repository/repertoires/repertoires.tsx
@@ -53,7 +53,7 @@ export const putRepertoire = async (id: string, nameRepertory: string, moveNodes
   });
   const data = await response.json();
   return data;
-}
+};
 
 export const putRepertoireName = async (id: string, nameRepertory: string) => {
   const response = await fetch(`${API_URL}/repertoires/${id}/name`, {
@@ -65,7 +65,7 @@ export const putRepertoireName = async (id: string, nameRepertory: string) => {
   });
   const data = await response.json();
   return data;
-}
+};
 
 export const putRepertoireOrderUp = async (id: string) => {
   const response = await fetch(`${API_URL}/repertoires/${id}/order/up`, {
@@ -73,7 +73,7 @@ export const putRepertoireOrderUp = async (id: string) => {
   });
   const data = await response.json();
   return data;
-}
+};
 
 export const deleteRepertoire = async (id: string) => {
   const response = await fetch(`${API_URL}/repertoires/${id}`, {
@@ -81,5 +81,21 @@ export const deleteRepertoire = async (id: string) => {
   });
   const data = await response.json();
   return data;
-}
+};
+
+export const enableRepertoire = async (id: string) => {
+  const response = await fetch(`${API_URL}/repertoires/${id}/enable`, {
+    method: "PUT",
+  });
+  const data = await response.json();
+  return data;
+};
+
+export const disableRepertoire = async (id: string) => {
+  const response = await fetch(`${API_URL}/repertoires/${id}/disable`, {
+    method: "PUT",
+  });
+  const data = await response.json();
+  return data;
+};
 


### PR DESCRIPTION
This pull request introduces significant backend and frontend changes to support enabling and disabling repertoires, improve repertoire filtering, and enhance the user experience. Key updates include adding new API endpoints, updating the data models, and integrating functionality into the frontend dashboard.

### Backend Changes

#### Repertoire Management:
* Added `disableRepertoire` and `enableRepertoire` functions in `repertoiresController.ts` to toggle the `disabled` status of repertoires in the database. (`[packages/backend/src/controllers/repertoiresController.tsR291-R321](diffhunk://#diff-f7f91d32772bf5d2be66f35f7a8aee651661269d87f13f5616b1298bab14f0f5R291-R321)`)
* Updated `Repertoire` model to include an optional `disabled` property. (`[packages/backend/src/models/Repertoire.tsR29](diffhunk://#diff-6f16e96fcc11428cf8546c27d7e41d3be7b20595ebd1ca6bcf056ddf9873468fR29)`)

#### Path and Variants Filtering:
* Introduced a `repertoireStatusMap` in `getPaths` to filter out variants belonging to disabled repertoires. (`[packages/backend/src/controllers/pathsController.tsL18-R47](diffhunk://#diff-9d5be59ef59a7427aa040723935a2183fe58da42924b8d0c5534e5ddd97fce1fL18-R47)`)
* Added a utility function `getRepertoireName` to fetch repertoire names by ID for improved variant display. (`[packages/backend/src/controllers/pathsController.tsR6-R11](diffhunk://#diff-9d5be59ef59a7427aa040723935a2183fe58da42924b8d0c5534e5ddd97fce1fR6-R11)`)
* Updated `Path` model to include a `repertoireName` field for better context in the frontend. (`[packages/backend/src/models/Path.tsR9](diffhunk://#diff-212db5504301e8d215291c929eb6f4469083026addafd690b49613097145151dR9)`)

### Frontend Changes

#### Dashboard Enhancements:
* Integrated `enableRepertoire` and `disableRepertoire` functionality into the `RepertoireCard` component, allowing users to toggle repertoire status directly from the dashboard. (`[[1]](diffhunk://#diff-1abf39384c32fcaafbec735dfc82a1f6715c1a06f8812dbcd29842e32c252753L2-R15)`, `[[2]](diffhunk://#diff-1abf39384c32fcaafbec735dfc82a1f6715c1a06f8812dbcd29842e32c252753L21-R72)`)
* Updated `RepertoiresSection` and `DashboardPage` to pass the `updateRepertoires` callback, ensuring the UI reflects changes in repertoire status. (`[[1]](diffhunk://#diff-90d436ee4e5795edf4eecb94dcf1298738b9d4b91733e345e27b9ac47ed32a29R17)`, `[[2]](diffhunk://#diff-37d106f589fdcb3b607fcb692ca537fc948c3083553ec2212ef309e53a4496b9L19-R19)`)

#### Path Page Improvements:
* Modified the `PathPage` to display the repertoire name alongside variant details, providing more context for the user. (`[packages/frontend/src/pages/PathPage/PathPage.tsxL51-R51](diffhunk://#diff-6be915067d6e1f6fccafa0954fd744577c7cbb026820c8a64ee049628fc281e4L51-R51)`)

### Tests and Miscellaneous
* Added `updateRepertoires` mock implementations in `DashboardPage` tests to ensure proper coverage of the new functionality. (`[[1]](diffhunk://#diff-3131e2eae3a9077daac761ed4cc43b0cdc05827289121b07b149b4c80a1d5647R36)`, `[[2]](diffhunk://#diff-3131e2eae3a9077daac761ed4cc43b0cdc05827289121b07b149b4c80a1d5647R125)`)
* Fixed a typo in the `duplicateRepertoire` route definition. (`[packages/backend/src/routes/repertoires.tsL26-R34](diffhunk://#diff-d80f659409234fee226e0b7bb024f83935895d7bfeb7d14739e95f8681a43678L26-R34)`)