### PR TITLE
feat: Add functionality to delete variants from paths and update related components

### DIFF
--- a/packages/backend/src/controllers/pathsController.ts
+++ b/packages/backend/src/controllers/pathsController.ts
@@ -81,9 +81,14 @@ export async function getPaths(req: Request, res: Response, next: NextFunction) 
 
     let result: Path;
     if (variantToReview && (!studyToReview || variantToReview.errors > 0)) {
+      
+      const variantId = typeof variantToReview._id === 'object' && '$oid' in variantToReview._id 
+        ? variantToReview._id.$oid 
+        : String(variantToReview._id);
+        
       result = {
         type: "variant",
-        _id: variantToReview._id,
+        id: variantId,
         repertoireId: variantToReview.repertoireId,
         repertoireName: await getRepertoireName(db, variantToReview.repertoireId),
         name: variantToReview.variantName,

--- a/packages/backend/src/controllers/pathsController.ts
+++ b/packages/backend/src/controllers/pathsController.ts
@@ -5,6 +5,14 @@ import { StudySession } from "../models/Study";
 import { Path } from "../models/Path";
 import { Db, ObjectId } from "mongodb";
 
+type VariantIdType = { $oid: string } | string | ObjectId;
+
+const extractVariantId = (variantId: VariantIdType): string => {
+  return typeof variantId === 'object' && '$oid' in variantId 
+    ? variantId.$oid 
+    : String(variantId);
+};
+
 const getRepertoireName = async (db: Db, repertoireId: string): Promise<string> => {
   const repertoire = await db.collection("repertoires").findOne({ _id: new ObjectId(repertoireId) });
   return repertoire ? repertoire.name : "Unknown Repertoire";
@@ -82,9 +90,7 @@ export async function getPaths(req: Request, res: Response, next: NextFunction) 
     let result: Path;
     if (variantToReview && (!studyToReview || variantToReview.errors > 0)) {
       
-      const variantId = typeof variantToReview._id === 'object' && '$oid' in variantToReview._id 
-        ? variantToReview._id.$oid 
-        : String(variantToReview._id);
+      const variantId = extractVariantId(variantToReview._id);
         
       result = {
         type: "variant",

--- a/packages/backend/src/controllers/repertoiresController.ts
+++ b/packages/backend/src/controllers/repertoiresController.ts
@@ -192,6 +192,19 @@ export async function postVariantsInfo(req: Request, res: Response, next: NextFu
   }
 }
 
+export async function deleteVariantsInfo(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { id } = req.params;
+    const db = getDB();
+    await db.collection("variantsInfo").deleteOne({ _id: new ObjectId(id) });
+    res.json({ message: "Variant info deleted" });
+  } catch (err) {
+    next(err);
+  }
+}
+
+
+
 export async function updateRepertoire(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;

--- a/packages/backend/src/controllers/repertoiresController.ts
+++ b/packages/backend/src/controllers/repertoiresController.ts
@@ -197,13 +197,11 @@ export async function deleteVariantsInfo(req: Request, res: Response, next: Next
     const { id } = req.params;
     const db = getDB();
     await db.collection("variantsInfo").deleteOne({ _id: new ObjectId(id) });
-    res.json({ message: "Variant info deleted" });
+    res.status(204).send();
   } catch (err) {
     next(err);
   }
 }
-
-
 
 export async function updateRepertoire(req: Request, res: Response, next: NextFunction) {
   try {

--- a/packages/backend/src/controllers/repertoiresController.ts
+++ b/packages/backend/src/controllers/repertoiresController.ts
@@ -192,7 +192,7 @@ export async function postVariantsInfo(req: Request, res: Response, next: NextFu
   }
 }
 
-export async function deleteVariantsInfo(req: Request, res: Response, next: NextFunction) {
+export async function deleteVariantInfo(req: Request, res: Response, next: NextFunction) {
   try {
     const { id } = req.params;
     const db = getDB();

--- a/packages/backend/src/models/Path.ts
+++ b/packages/backend/src/models/Path.ts
@@ -4,7 +4,7 @@ export type Path =
   | { message: string };
 
 export type PathVariant = {
-  _id: { $oid: string };
+  id: string;
   repertoireId: string;
   repertoireName: string;
   name: string;

--- a/packages/backend/src/routes/repertoires.ts
+++ b/packages/backend/src/routes/repertoires.ts
@@ -15,7 +15,7 @@ import {
   deleteRepertoire,
   disableRepertoire,
   enableRepertoire,
-  deleteVariantsInfo
+  deleteVariantInfo
 } from "../controllers/repertoiresController";
 
 const router = Router();
@@ -29,7 +29,7 @@ router.post("/", createRepertoire);
 router.post("/:id/duplicate", duplicateRepertoire);
 router.get("/:id/variantsInfo", getVariantsInfo);
 router.post("/:id/variantsInfo", postVariantsInfo);
-router.delete("/:id/variantsInfo", deleteVariantsInfo);
+router.delete("/:id/variantsInfo", deleteVariantInfo);
 router.put("/:id", updateRepertoire);
 router.put("/:id/name", updateRepertoireName);
 router.put("/:id/enable", enableRepertoire);

--- a/packages/backend/src/routes/repertoires.ts
+++ b/packages/backend/src/routes/repertoires.ts
@@ -14,7 +14,8 @@ import {
   moveRepertoireOrderUp,
   deleteRepertoire,
   disableRepertoire,
-  enableRepertoire
+  enableRepertoire,
+  deleteVariantsInfo
 } from "../controllers/repertoiresController";
 
 const router = Router();
@@ -28,6 +29,7 @@ router.post("/", createRepertoire);
 router.post("/:id/duplicate", duplicateRepertoire);
 router.get("/:id/variantsInfo", getVariantsInfo);
 router.post("/:id/variantsInfo", postVariantsInfo);
+router.delete("/:id/variantsInfo", deleteVariantsInfo);
 router.put("/:id", updateRepertoire);
 router.put("/:id/name", updateRepertoireName);
 router.put("/:id/enable", enableRepertoire);

--- a/packages/frontend/src/hooks/usePaths.tsx
+++ b/packages/frontend/src/hooks/usePaths.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { fetchPath } from "../repository/paths/paths";
+import { fetchPath, deleteVariantFromPath } from "../repository/paths/paths";
 import { Path } from "../models/Path";
 
 export function usePaths() {
@@ -20,5 +20,20 @@ export function usePaths() {
     }
   }, []);
 
-  return { path, loading, error, loadPath };
+  const removeVariantFromPath = useCallback(async (variantId: string) => {
+    if (!variantId) return;
+    
+    setLoading(true);
+    setError(null);
+    try {
+      await deleteVariantFromPath(variantId);
+      await loadPath(); // Reload path data after removal
+    } catch (err: any) {
+      setError(err.message || "Failed to remove variant from path");
+    } finally {
+      setLoading(false);
+    }
+  }, [loadPath]);
+
+  return { path, loading, error, loadPath, removeVariantFromPath };
 }

--- a/packages/frontend/src/hooks/usePaths.tsx
+++ b/packages/frontend/src/hooks/usePaths.tsx
@@ -21,7 +21,10 @@ export function usePaths() {
   }, []);
 
   const removeVariantFromPath = useCallback(async (variantId: string) => {
-    if (!variantId) return;
+    if (!variantId) {
+      console.warn("removeVariantFromPath called with a falsy variantId");
+      return;
+    }
     
     setLoading(true);
     setError(null);

--- a/packages/frontend/src/pages/PathPage/PathPage.tsx
+++ b/packages/frontend/src/pages/PathPage/PathPage.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect } from "react";
 import { usePaths } from "../../hooks/usePaths";
-import { AcademicCapIcon, BookOpenIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
+import { useDialogContext } from "../../contexts/DialogContext";
+import { AcademicCapIcon, BookOpenIcon, ArrowPathIcon, XMarkIcon } from "@heroicons/react/24/outline";
 
 const PathPage: React.FC = () => {
-  const { path, loading, error, loadPath } = usePaths();
+  const { path, loading, error, loadPath, removeVariantFromPath } = usePaths();
+  const { showConfirmDialog } = useDialogContext();
 
   useEffect(() => {
     loadPath();
@@ -24,6 +26,18 @@ const PathPage: React.FC = () => {
   const goToReviewVariant = () => {
     if (path?.type === "variant" && path.repertoireId) {
       window.location.href = `/repertoire/${path.repertoireId}?variantName=${path.name}`;
+    }
+  };
+
+  const handleRemoveVariant = async () => {
+    if (path?.type === "variant" && path.id) {
+      showConfirmDialog({
+        title: "Remove Variant from Path",
+        contentText: `Are you sure you want to remove "${path.name}" from your learning path? This will reset all training progress for this variant and it will no longer appear in your spaced repetition schedule.`,
+        onConfirm: async () => {
+          await removeVariantFromPath(path.id);
+        }
+      });
     }
   };
 
@@ -66,6 +80,13 @@ const PathPage: React.FC = () => {
                           Start Training
                         </button>
                       </div>
+                      <button
+                        className="mt-4 px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded font-semibold flex items-center justify-center gap-2 w-full"
+                        onClick={handleRemoveVariant}
+                      >
+                        <XMarkIcon className="h-5 w-5" />
+                        Remove this variant from path
+                      </button>
                     </>
                   )}
                   {path.type === "study" && path.id && (

--- a/packages/frontend/src/repository/paths/paths.ts
+++ b/packages/frontend/src/repository/paths/paths.ts
@@ -6,3 +6,11 @@ export async function fetchPath(): Promise<Path> {
   if (!res.ok) throw new Error("Failed to fetch path");
   return res.json();
 }
+
+export async function deleteVariantFromPath(variantId: string): Promise<void> {
+  const res = await fetch(`${API_URL}/repertoires/${variantId}/variantsInfo`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) throw new Error("Failed to remove variant from path");
+  return res.json();
+}

--- a/packages/frontend/src/repository/paths/paths.ts
+++ b/packages/frontend/src/repository/paths/paths.ts
@@ -12,5 +12,4 @@ export async function deleteVariantFromPath(variantId: string): Promise<void> {
     method: 'DELETE',
   });
   if (!res.ok) throw new Error("Failed to remove variant from path");
-  return res.json();
 }


### PR DESCRIPTION
This pull request introduces functionality to delete a variant from a learning path and updates both the backend and frontend to support this feature. Key changes include adding a new backend endpoint for deleting variants, modifying the frontend to integrate this functionality, and updating the `Path` model to reflect the changes.

### Backend Changes:
* **New Endpoint for Deleting Variants**: Added `deleteVariantsInfo` function in `repertoiresController` to handle deletion of variant information by ID. This is exposed via a new `DELETE` route in `repertoires.ts`. [[1]](diffhunk://#diff-f7f91d32772bf5d2be66f35f7a8aee651661269d87f13f5616b1298bab14f0f5R195-R207) [[2]](diffhunk://#diff-d80f659409234fee226e0b7bb024f83935895d7bfeb7d14739e95f8681a43678R32)
* **Model Update**: Updated the `PathVariant` type in `Path.ts` to replace `_id` with `id` for consistency and clarity.
* **Refactor in `pathsController.ts`**: Adjusted how variant IDs are handled to ensure compatibility with the updated `PathVariant` type.

### Frontend Changes:
* **Hook Update**: Enhanced `usePaths` hook to include `removeVariantFromPath`, which calls the new backend endpoint and reloads the path data after a variant is removed. [[1]](diffhunk://#diff-a4d1cd4b00d1fc3fdd4d0f91f23869f164f9e982a46f8b1af7af2f43f41a1cfcL2-R2) [[2]](diffhunk://#diff-a4d1cd4b00d1fc3fdd4d0f91f23869f164f9e982a46f8b1af7af2f43f41a1cfcL23-R38)
* **UI Integration**: Updated `PathPage` to include a button for removing a variant from the path. This triggers a confirmation dialog before calling the `removeVariantFromPath` function. [[1]](diffhunk://#diff-6be915067d6e1f6fccafa0954fd744577c7cbb026820c8a64ee049628fc281e4L3-R8) [[2]](diffhunk://#diff-6be915067d6e1f6fccafa0954fd744577c7cbb026820c8a64ee049628fc281e4R32-R43) [[3]](diffhunk://#diff-6be915067d6e1f6fccafa0954fd744577c7cbb026820c8a64ee049628fc281e4R83-R89)

### API Changes:
* **New API Function**: Added `deleteVariantFromPath` in `paths.ts` to send a `DELETE` request to the backend for removing a variant.