### PR TITLE
feat: add orientation prop to HintInfo component and update FEN calculation

### DIFF
--- a/packages/frontend/src/components/design/chess/train/HintInfo.tsx
+++ b/packages/frontend/src/components/design/chess/train/HintInfo.tsx
@@ -4,13 +4,15 @@ import { MoveVariantNode } from "../../../../models/VariantNode";
 import { Textarea } from "@headlessui/react";
 import { useDialogContext } from "../../../../contexts/DialogContext";
 import { getPositionComment } from "../../../../repository/positions/positions";
+import { BoardOrientation, getOrientationAwareFen } from "@chess-opening-master/common";
 
 interface HintInfoProps {
   currentMoveNode: MoveVariantNode;
+  orientation: BoardOrientation;
   updateComment: (comment: string) => Promise<void>;
 }
 
-const getFenForNode = (node: MoveVariantNode): string => {
+const getFenForNode = (node: MoveVariantNode, orientation: BoardOrientation): string => {
   const movePath: MoveVariantNode[] = [];
   let currentNode: MoveVariantNode | null = node;
 
@@ -24,11 +26,13 @@ const getFenForNode = (node: MoveVariantNode): string => {
     chess.move(moveNode.getMove());
   }
 
-  return chess.fen();
+  const fen = chess.fen();
+  return getOrientationAwareFen(fen, orientation);
 };
 
 export const HintInfo: React.FC<HintInfoProps> = ({
   currentMoveNode,
+  orientation,
   updateComment,
 }) => {
   const { showTextAreaDialog } = useDialogContext();
@@ -42,7 +46,7 @@ export const HintInfo: React.FC<HintInfoProps> = ({
         comments.push(node.toString());
 
         try {
-          const positionFen = getFenForNode(node);
+          const positionFen = getFenForNode(node, orientation);
           const comment = await getPositionComment(positionFen);
           comments.push(comment || "No comment");
         } catch (error) {
@@ -64,7 +68,7 @@ export const HintInfo: React.FC<HintInfoProps> = ({
   }, [loadHints]);
   const handleUpdateComment = async () => {
     try {
-      const positionFen = getFenForNode(currentMoveNode);
+      const positionFen = getFenForNode(currentMoveNode, orientation);
       const currentComment = await getPositionComment(positionFen);
 
       showTextAreaDialog({

--- a/packages/frontend/src/pages/repertoires/TrainRepertoirePage/TrainRepertoireViewContainer.tsx
+++ b/packages/frontend/src/pages/repertoires/TrainRepertoirePage/TrainRepertoireViewContainer.tsx
@@ -25,7 +25,7 @@ const TrainRepertoireViewContainer: React.FC = () => {
     "info" | "help" | "trainComments"
   >("info");
   const navigate = useNavigate();
-  const { repertoireId, repertoireName, currentMoveNode, variants, updateComment } =
+  const { repertoireId, repertoireName, currentMoveNode, orientation, variants, updateComment } =
     useRepertoireContext();
   const { showTrainVariantsDialog, showNumberDialog } = useDialogContext();
   const { addIcon: addIconHeader, removeIcon: removeIconHeader } =
@@ -170,12 +170,12 @@ const TrainRepertoireViewContainer: React.FC = () => {
             <HelpInfo allowedMoves={allowedMoves} isYourTurn={isYourTurn} />
           )}
           {panelSelected === "trainComments" && (
-            <HintInfo currentMoveNode={currentMoveNode} updateComment={updateComment} />
+            <HintInfo currentMoveNode={currentMoveNode} orientation={orientation} updateComment={updateComment} />
           )}
         </div>
         <div className="hidden sm:flex flex-col space-y-4 h-full">
-          <div className="h-2/5"><HintInfo currentMoveNode={currentMoveNode} updateComment={updateComment} /></div>
-          
+          <div className="h-2/5"><HintInfo currentMoveNode={currentMoveNode} orientation={orientation} updateComment={updateComment} /></div>
+
           <TrainInfo
             currentMoveNode={currentMoveNode}
             turn={turn}


### PR DESCRIPTION
This pull request updates the `HintInfo` component and its dependencies to support orientation-aware FEN generation in a chess training application. The changes ensure that the chessboard orientation is considered when generating FEN strings, improving the accuracy of position-related functionality.

### Updates to `HintInfo` Component:

* **Orientation-aware FEN generation**: Modified the `getFenForNode` function in `HintInfo.tsx` to accept an `orientation` parameter and use `getOrientationAwareFen` for generating FEN strings based on the board orientation. [[1]](diffhunk://#diff-53b3feeb91e387e46f10fb7bdc16b12a40a405e9324bfff8076337236f1f191fR7-R15) [[2]](diffhunk://#diff-53b3feeb91e387e46f10fb7bdc16b12a40a405e9324bfff8076337236f1f191fL27-R35)
* **Integration of orientation in `HintInfo` props**: Added the `orientation` prop to the `HintInfo` component and updated all calls to `getFenForNode` within the component to include the orientation parameter. [[1]](diffhunk://#diff-53b3feeb91e387e46f10fb7bdc16b12a40a405e9324bfff8076337236f1f191fL45-R49) [[2]](diffhunk://#diff-53b3feeb91e387e46f10fb7bdc16b12a40a405e9324bfff8076337236f1f191fL67-R71)

### Updates to `TrainRepertoireViewContainer`:

* **Passing orientation to `HintInfo`**: Updated `TrainRepertoireViewContainer.tsx` to pass the `orientation` prop from `useRepertoireContext` to the `HintInfo` component wherever it is rendered. [[1]](diffhunk://#diff-fb1987f84b2413df45535c6ee9ddacbc34d7e7c5533b6aec15e50afb99ab3ed2L28-R28) [[2]](diffhunk://#diff-fb1987f84b2413df45535c6ee9ddacbc34d7e7c5533b6aec15e50afb99ab3ed2L173-R177)