### PR TITLE
feat: refactor variant navigation logic and enhance RepertoireInfoPanel with training action

### DIFF
--- a/packages/frontend/src/components/application/chess/board/RepertoireInfo.test.tsx
+++ b/packages/frontend/src/components/application/chess/board/RepertoireInfo.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RepertoireInfo } from './RepertoireInfo';
+
+const mockHandleVariantChange = jest.fn();
+const mockToggleMenu = jest.fn();
+
+jest.mock('../../../../contexts/RepertoireContext', () => ({
+  useRepertoireContext: () => ({
+    variants: [
+      {
+        moves: [],
+        name: 'Test Variant',
+        fullName: 'Test Variant: Full Name',
+        differentMoves: '',
+      },
+    ],
+    currentMoveNode: {},
+    chess: { fen: () => 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1' },
+    changeNameMove: jest.fn(),
+    goToMove: jest.fn(),
+    deleteMove: jest.fn(),
+    comment: 'Test comment',
+    updateComment: jest.fn(),
+    selectedVariant: {
+      moves: [],
+      name: 'Test Variant',
+      fullName: 'Test Variant: Full Name',
+      differentMoves: '',
+    },
+    repertoireId: 'test-repertoire-id',
+  }),
+}));
+
+jest.mock('../../../../hooks/useRepertoireInfo', () => ({
+  useRepertoireInfo: () => ({
+    downloadVariantPGN: jest.fn(),
+    copyVariantPGN: jest.fn(),
+    copyVariantToRepertoire: jest.fn(),
+    copyVariantsToRepertoire: jest.fn(),
+    deleteVariants: jest.fn(),
+    deleteVariant: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../contexts/MenuContext', () => ({
+  useMenuContext: () => ({
+    toggleMenu: mockToggleMenu,
+  }),
+}));
+
+jest.mock('../../../../hooks/useVariantNavigation', () => ({
+  useVariantNavigation: () => ({
+    handleVariantChange: mockHandleVariantChange,
+  }),
+}));
+
+jest.mock('../../../design/chess/RepertoireInfoPanel/RepertoireInfoPanel', () => ({
+  RepertoireInfoPanel: (props: { setSelectedVariant: (variant: unknown) => void }) => (
+    <div data-testid="repertoire-info-panel">
+      <div>setSelectedVariant prop type: {typeof props.setSelectedVariant}</div>
+      <button onClick={() => props.setSelectedVariant(null)}>Test setSelectedVariant</button>
+    </div>
+  ),
+}));
+
+describe('RepertoireInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render successfully', () => {
+    const { getByTestId } = render(<RepertoireInfo />);
+    expect(getByTestId('repertoire-info-panel')).toBeInTheDocument();
+  });
+
+  it('should pass handleVariantChange as setSelectedVariant prop to RepertoireInfoPanel', () => {
+    const { getByText } = render(<RepertoireInfo />);
+    
+    expect(getByText('setSelectedVariant prop type: function')).toBeInTheDocument();
+  });
+
+  it('should call handleVariantChange when setSelectedVariant is invoked', () => {
+    const { getByText } = render(<RepertoireInfo />);
+    
+    const testButton = getByText('Test setSelectedVariant');
+    testButton.click();
+    
+    expect(mockHandleVariantChange).toHaveBeenCalledWith(null);
+  });
+
+  it('should use the new useVariantNavigation hook instead of inline logic', () => {
+    render(<RepertoireInfo />);
+    
+    expect(mockHandleVariantChange).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/application/chess/board/RepertoireInfo.tsx
+++ b/packages/frontend/src/components/application/chess/board/RepertoireInfo.tsx
@@ -1,14 +1,11 @@
 import React from "react";
-import { useNavigate, useLocation } from "react-router-dom";
 import { RepertoireInfoPanel } from "../../../design/chess/RepertoireInfoPanel/RepertoireInfoPanel";
 import { useRepertoireContext } from "../../../../contexts/RepertoireContext";
 import { useRepertoireInfo } from "../../../../hooks/useRepertoireInfo";
 import { useMenuContext } from "../../../../contexts/MenuContext";
-import { Variant } from "../../../../models/chess.models";
+import { useVariantNavigation } from "../../../../hooks/useVariantNavigation";
 
 export const RepertoireInfo = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
   const {
     variants,
     currentMoveNode,
@@ -19,27 +16,11 @@ export const RepertoireInfo = () => {
     comment,
     updateComment,
     selectedVariant,
-    setSelectedVariant,
     repertoireId,
-    initBoard,
   } = useRepertoireContext();
 
   const { toggleMenu } = useMenuContext();
-
-  const handleVariantChange = (variant: Variant | null) => {
-    setSelectedVariant(variant);
-    initBoard();
-    
-    const currentParams = new URLSearchParams(location.search);
-    if (variant?.fullName) {
-      currentParams.set("variantName", variant.fullName);
-    } else {
-      currentParams.delete("variantName");
-    }
-    
-    const newUrl = `${location.pathname}?${currentParams.toString()}`;
-    navigate(newUrl, { replace: true });
-  };
+  const { handleVariantChange } = useVariantNavigation();
 
   const { downloadVariantPGN, copyVariantPGN,copyVariantToRepertoire,copyVariantsToRepertoire,deleteVariants, deleteVariant } =
     useRepertoireInfo();

--- a/packages/frontend/src/components/application/chess/board/VariantsInfo.test.tsx
+++ b/packages/frontend/src/components/application/chess/board/VariantsInfo.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VariantsInfo from './VariantsInfo';
+
+const mockHandleVariantChange = jest.fn();
+
+jest.mock('../../../../contexts/RepertoireContext', () => ({
+  useRepertoireContext: () => ({
+    variants: [
+      {
+        moves: [],
+        name: 'Test Variant',
+        fullName: 'Test Variant: Full Name',
+        differentMoves: '',
+      },
+    ],
+    repertoireId: 'test-repertoire-id',
+    currentMoveNode: {},
+    orientation: 'white',
+    changeNameMove: jest.fn(),
+    goToMove: jest.fn(),
+    deleteMove: jest.fn(),
+    selectedVariant: {
+      moves: [],
+      name: 'Test Variant',
+      fullName: 'Test Variant: Full Name',
+      differentMoves: '',
+    },
+  }),
+}));
+
+jest.mock('../../../../contexts/DialogContext', () => ({
+  useDialogContext: jest.fn(),
+}));
+
+jest.mock('../../../../contexts/AlertContext', () => ({
+  useAlertContext: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useRepertoireInfo', () => ({
+  useRepertoireInfo: () => ({
+    deleteVariant: jest.fn(),
+    copyVariantToRepertoire: jest.fn(),
+    copyVariantsToRepertoire: jest.fn(),
+    deleteVariants: jest.fn(),
+    copyVariantPGN: jest.fn(),
+    downloadVariantPGN: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../hooks/useVariantNavigation', () => ({
+  useVariantNavigation: () => ({
+    handleVariantChange: mockHandleVariantChange,
+  }),
+}));
+
+jest.mock('../../../design/chess/VariantTree/VariantTree', () => ({
+  __esModule: true,
+  default: (props: { setSelectedVariant: (variant: unknown) => void }) => (
+    <div data-testid="variant-tree">
+      <div>setSelectedVariant prop type: {typeof props.setSelectedVariant}</div>
+      <button onClick={() => props.setSelectedVariant(null)}>Test setSelectedVariant</button>
+    </div>
+  ),
+}));
+
+describe('VariantsInfo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render successfully', () => {
+    const { getByTestId } = render(<VariantsInfo />);
+    expect(getByTestId('variant-tree')).toBeInTheDocument();
+  });
+
+  it('should pass handleVariantChange as setSelectedVariant prop to VariantTree', () => {
+    const { getByText } = render(<VariantsInfo />);
+    
+    expect(getByText('setSelectedVariant prop type: function')).toBeInTheDocument();
+  });
+
+  it('should call handleVariantChange when setSelectedVariant is invoked', () => {
+    const { getByText } = render(<VariantsInfo />);
+    
+    const testButton = getByText('Test setSelectedVariant');
+    testButton.click();
+    
+    expect(mockHandleVariantChange).toHaveBeenCalledWith(null);
+  });
+
+  it('should use the new useVariantNavigation hook instead of inline logic', () => {
+    render(<VariantsInfo />);
+    
+    expect(mockHandleVariantChange).toBeDefined();
+  });
+});

--- a/packages/frontend/src/components/application/chess/board/VariantsInfo.tsx
+++ b/packages/frontend/src/components/application/chess/board/VariantsInfo.tsx
@@ -4,6 +4,7 @@ import VariantsTree from "../../../design/chess/VariantTree/VariantTree";
 import { useDialogContext } from "../../../../contexts/DialogContext";
 import { useAlertContext } from "../../../../contexts/AlertContext";
 import { useRepertoireInfo } from "../../../../hooks/useRepertoireInfo";
+import { useVariantNavigation } from "../../../../hooks/useVariantNavigation";
 
 const VariantsInfo: React.FC = () => {
   const {
@@ -14,7 +15,10 @@ const VariantsInfo: React.FC = () => {
     changeNameMove,
     goToMove,
     deleteMove,
+    selectedVariant,
   } = useRepertoireContext();
+
+  const { handleVariantChange } = useVariantNavigation();
 
   useDialogContext();
   useAlertContext();
@@ -26,7 +30,6 @@ const VariantsInfo: React.FC = () => {
       <VariantsTree
         variants={variants}
         repertoireId={repertoireId}
-        currentNode={currentMoveNode}
         orientation={orientation}
         deleteVariant={deleteVariant}
         copyVariantToRepertoire={copyVariantToRepertoire}
@@ -38,6 +41,8 @@ const VariantsInfo: React.FC = () => {
         deleteMove={deleteMove}
         goToMove={goToMove}
         currentMoveNode={currentMoveNode}
+        selectedVariant={selectedVariant}
+        setSelectedVariant={handleVariantChange}
       ></VariantsTree>
 
   );

--- a/packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.test.tsx
+++ b/packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.test.tsx
@@ -45,11 +45,6 @@ global.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
-interface MenuAction {
-  name: string;
-  action: () => void;
-}
-
 const createMockMoveNode = (id: string): MoveVariantNode => {
   const node = new MoveVariantNode();
   node.id = id;
@@ -116,34 +111,12 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
     it('should call goToTrainRepertoire with correct repertoireId and selectedVariant fullName when Train variant is clicked', () => {
       render(<RepertoireInfoPanel {...defaultProps} />);
       
-      const moreOptionsButton = screen.getAllByRole('button').find(button => 
-        button.querySelector('svg path[d*="12 6.75a.75.75"]')
-      );
+      const trainButton = screen.getByText('Train').closest('div')?.querySelector('button');
       
-      expect(moreOptionsButton).toBeInTheDocument();
+      expect(trainButton).toBeInTheDocument();
       
-      if (moreOptionsButton) {
-        fireEvent.click(moreOptionsButton);
-      }
-      
-      expect(defaultProps.toggleMenu).toHaveBeenCalledWith(
-        expect.any(HTMLElement),
-        expect.arrayContaining([
-          expect.objectContaining({
-            name: 'Train variant',
-            action: expect.any(Function),
-          }),
-        ])
-      );
-      
-      const toggleMenuCall = defaultProps.toggleMenu.mock.calls[0];
-      const secondaryActions = toggleMenuCall[1];
-      const trainVariantAction = secondaryActions.find((item: MenuAction) => item.name === 'Train variant');
-      
-      expect(trainVariantAction).toBeDefined();
-      
-      if (trainVariantAction) {
-        trainVariantAction.action();
+      if (trainButton) {
+        fireEvent.click(trainButton);
       }
       
       expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
@@ -157,25 +130,14 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
       const newProps = {
         ...defaultProps,
         selectedVariant: newSelectedVariant,
-        toggleMenu: jest.fn(),
       };
       
       render(<RepertoireInfoPanel {...newProps} />);
       
-      const moreOptionsButton = screen.getAllByRole('button').find(button => 
-        button.querySelector('svg path[d*="12 6.75a.75.75"]')
-      );
+      const trainButton = screen.getByText('Train').closest('div')?.querySelector('button');
       
-      if (moreOptionsButton) {
-        fireEvent.click(moreOptionsButton);
-      }
-      
-      const toggleMenuCall = newProps.toggleMenu.mock.calls[0];
-      const secondaryActions = toggleMenuCall[1];
-      const trainVariantAction = secondaryActions.find((item: MenuAction) => item.name === 'Train variant');
-      
-      if (trainVariantAction) {
-        trainVariantAction.action();
+      if (trainButton) {
+        fireEvent.click(trainButton);
       }
       
       expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
@@ -188,31 +150,20 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
       const propsWithoutSelectedVariant = {
         ...defaultProps,
         selectedVariant: undefined as unknown as Variant,
-        toggleMenu: jest.fn(),
       };
       
       render(<RepertoireInfoPanel {...propsWithoutSelectedVariant} />);
       
-      const moreOptionsButton = screen.getAllByRole('button').find(button => 
-        button.querySelector('svg path[d*="12 6.75a.75.75"]')
-      );
+      const trainButton = screen.getByText('Train').closest('div')?.querySelector('button');
       
-      if (moreOptionsButton) {
-        fireEvent.click(moreOptionsButton);
-      }
-      
-      const toggleMenuCall = propsWithoutSelectedVariant.toggleMenu.mock.calls[0];
-      const secondaryActions = toggleMenuCall[1];
-      const trainVariantAction = secondaryActions.find((item: MenuAction) => item.name === 'Train variant');
-      
-      if (trainVariantAction) {
-        trainVariantAction.action();
+      if (trainButton) {
+        fireEvent.click(trainButton);
       }
       
       expect(mockGoToTrainRepertoire).not.toHaveBeenCalled();
     });
 
-    it('should include Train variant action in secondaryActions array with correct properties', () => {
+    it('should include correct actions in secondaryActions array with correct properties', () => {
       render(<RepertoireInfoPanel {...defaultProps} />);
       
       const moreOptionsButton = screen.getAllByRole('button').find(button => 
@@ -227,10 +178,6 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
       const secondaryActions = toggleMenuCall[1];
       
       expect(secondaryActions).toEqual([
-        expect.objectContaining({
-          name: 'Train variant',
-          action: expect.any(Function),
-        }),
         expect.objectContaining({
           name: 'Copy variant to repertoire',
           action: expect.any(Function),
@@ -255,20 +202,10 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
       
       render(<RepertoireInfoPanel {...customProps} />);
       
-      const moreOptionsButton = screen.getAllByRole('button').find(button => 
-        button.querySelector('svg path[d*="12 6.75a.75.75"]')
-      );
+      const trainButton = screen.getByText('Train').closest('div')?.querySelector('button');
       
-      if (moreOptionsButton) {
-        fireEvent.click(moreOptionsButton);
-      }
-      
-      const toggleMenuCall = defaultProps.toggleMenu.mock.calls[0];
-      const secondaryActions = toggleMenuCall[1];
-      const trainVariantAction = secondaryActions.find((item: MenuAction) => item.name === 'Train variant');
-      
-      if (trainVariantAction) {
-        trainVariantAction.action();
+      if (trainButton) {
+        fireEvent.click(trainButton);
       }
       
       expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
@@ -292,20 +229,10 @@ describe('RepertoireInfoPanel - Train Variant Action', () => {
       
       render(<RepertoireInfoPanel {...customProps} />);
       
-      const moreOptionsButton = screen.getAllByRole('button').find(button => 
-        button.querySelector('svg path[d*="12 6.75a.75.75"]')
-      );
+      const trainButton = screen.getByText('Train').closest('div')?.querySelector('button');
       
-      if (moreOptionsButton) {
-        fireEvent.click(moreOptionsButton);
-      }
-      
-      const toggleMenuCall = defaultProps.toggleMenu.mock.calls[0];
-      const secondaryActions = toggleMenuCall[1];
-      const trainVariantAction = secondaryActions.find((item: MenuAction) => item.name === 'Train variant');
-      
-      if (trainVariantAction) {
-        trainVariantAction.action();
+      if (trainButton) {
+        fireEvent.click(trainButton);
       }
       
       expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(

--- a/packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.tsx
+++ b/packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.tsx
@@ -7,6 +7,7 @@ import {
   EllipsisVerticalIcon,
   PresentationChartLineIcon,
   TrashIcon,
+  AcademicCapIcon,
 } from "@heroicons/react/24/outline";
 import useStockfish from "../../../../libs/useStockfish";
 import { StockfishSubpanel } from "./StockfishSubpanel";
@@ -82,6 +83,11 @@ export const RepertoireInfoPanel: React.FC<RepertoireInfoPanelProps> = ({
 
   const actions = [
     {
+      onClick: () => selectedVariant && goToTrainRepertoire(repertoireId, selectedVariant.fullName),
+      icon: <AcademicCapIcon className="h-5 w-5 text-accent" />,
+      label: "Train",
+    },
+    {
       onClick: () => selectedVariant && downloadVariantPGN(selectedVariant),
       icon: <ArrowDownTrayIcon className="h-5 w-5 text-accent" />,
       label: "Download",
@@ -89,7 +95,7 @@ export const RepertoireInfoPanel: React.FC<RepertoireInfoPanelProps> = ({
     {
       onClick: () => selectedVariant && copyVariantPGN(selectedVariant),
       icon: <ClipboardIcon className="h-5 w-5 text-accent" />,
-      label: "Copy",
+      label: "Copy PGN",
     },
     {
       onClick: () => selectedVariant && deleteVariant(selectedVariant),
@@ -99,10 +105,6 @@ export const RepertoireInfoPanel: React.FC<RepertoireInfoPanelProps> = ({
   ];
 
   const secondaryActions = [
-    {
-      name: "Train variant",
-      action: () => selectedVariant && goToTrainRepertoire(repertoireId, selectedVariant.fullName),
-    },
     {
       name: "Copy variant to repertoire",
       action: () => selectedVariant && copyVariantToRepertoire(selectedVariant),

--- a/packages/frontend/src/components/design/chess/VariantTree/VariantTree.test.tsx
+++ b/packages/frontend/src/components/design/chess/VariantTree/VariantTree.test.tsx
@@ -1,0 +1,292 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import VariantTree from './VariantTree';
+import { Variant } from '../../../../models/chess.models';
+import { MoveVariantNode } from '@chess-opening-master/common';
+
+const mockGoToTrainRepertoire = jest.fn();
+
+jest.mock('../../../../utils/navigationUtils', () => ({
+  useNavigationUtils: () => ({
+    goToTrainRepertoire: mockGoToTrainRepertoire,
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    pathname: '/repertoire/test-id',
+    search: '',
+  }),
+}));
+
+jest.mock('../../../../hooks/useTrainVariantInfo', () => ({
+  useTrainVariantInfo: () => ({
+    variantsInfo: [],
+    groupedVariantsInfo: {},
+    getColorFromVariant: jest.fn(() => '#4CAF50'),
+    getTextColorFromVariant: jest.fn(() => '#FFFFFF'),
+  }),
+}));
+
+global.fetch = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve([]),
+  })
+) as jest.Mock;
+
+const createMockMoveNode = (id: string): MoveVariantNode => {
+  const node = new MoveVariantNode();
+  node.id = id;
+  node.move = {
+    color: 'w',
+    piece: 'p',
+    from: 'e2',
+    to: 'e4',
+    san: 'e4',
+    flags: 'b',
+    lan: 'e2e4',
+    before: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+    after: 'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1',
+  };
+  return node;
+};
+
+const mockVariants: Variant[] = [
+  {
+    moves: [createMockMoveNode('move1')],
+    name: 'Italian Game',
+    fullName: 'Italian Game: Classical Variation',
+    differentMoves: '',
+  },
+  {
+    moves: [createMockMoveNode('move2')],
+    name: 'Sicilian Defense',
+    fullName: 'Sicilian Defense: Accelerated Dragon',
+    differentMoves: '',
+  },
+];
+
+const defaultProps = {
+  variants: mockVariants,
+  repertoireId: 'test-repertoire-123',
+  orientation: 'white' as const,
+  deleteVariant: jest.fn(),
+  copyVariantToRepertoire: jest.fn(),
+  downloadVariantPGN: jest.fn(),
+  copyVariantPGN: jest.fn(),
+  deleteVariants: jest.fn(),
+  copyVariantsToRepertoire: jest.fn(),
+  changeNameMove: jest.fn(),
+  deleteMove: jest.fn(),
+  goToMove: jest.fn(),
+  currentMoveNode: mockVariants[0].moves[0],
+  selectedVariant: mockVariants[0],
+  setSelectedVariant: jest.fn(),
+};
+
+describe('VariantTree', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Train action', () => {
+    it('should call goToTrainRepertoire with correct parameters when Train button is clicked', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const trainLabel = screen.getByText('Train');
+      expect(trainLabel).toBeInTheDocument();
+      
+      const trainButton = trainLabel.parentElement?.querySelector('button');
+      expect(trainButton).toBeInTheDocument();
+      
+      if (trainButton) {
+        fireEvent.click(trainButton);
+      }
+      
+      expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
+        defaultProps.repertoireId,
+        defaultProps.selectedVariant.fullName
+      );
+    });
+
+    it('should not call goToTrainRepertoire when selectedVariant is null', () => {
+      const propsWithoutVariant = {
+        ...defaultProps,
+        selectedVariant: null,
+      };
+      
+      render(<VariantTree {...propsWithoutVariant} />);
+      
+      expect(screen.queryByText('Train')).not.toBeInTheDocument();
+      expect(mockGoToTrainRepertoire).not.toHaveBeenCalled();
+    });
+
+    it('should use selectedVariant fullName not just name for training', () => {
+      const variantWithDifferentNames = {
+        moves: [createMockMoveNode('move3')],
+        name: 'Short Name',
+        fullName: 'Very Long Full Name: Complete Variation Details',
+        differentMoves: '',
+      };
+      
+      const customProps = {
+        ...defaultProps,
+        selectedVariant: variantWithDifferentNames,
+      };
+      
+      render(<VariantTree {...customProps} />);
+      
+      const trainLabel = screen.getByText('Train');
+      const trainButton = trainLabel.parentElement?.querySelector('button');
+      
+      if (trainButton) {
+        fireEvent.click(trainButton);
+      }
+      
+      expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
+        customProps.repertoireId,
+        variantWithDifferentNames.fullName
+      );
+      
+      expect(mockGoToTrainRepertoire).not.toHaveBeenCalledWith(
+        customProps.repertoireId,
+        variantWithDifferentNames.name
+      );
+    });
+  });
+
+  describe('Variant actions', () => {
+    it('should display all primary action buttons when selectedVariant exists', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      expect(screen.getByText('Train')).toBeInTheDocument();
+      expect(screen.getByText('Download')).toBeInTheDocument();
+      expect(screen.getByText('Copy PGN')).toBeInTheDocument();
+      expect(screen.getByText('Copy variant')).toBeInTheDocument();
+    });
+
+    it('should call downloadVariantPGN when Download button is clicked', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const downloadLabel = screen.getByText('Download');
+      const downloadButton = downloadLabel.parentElement?.querySelector('button');
+      
+      if (downloadButton) {
+        fireEvent.click(downloadButton);
+      }
+      
+      expect(defaultProps.downloadVariantPGN).toHaveBeenCalledWith(defaultProps.selectedVariant);
+    });
+
+    it('should call copyVariantPGN when Copy PGN button is clicked', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const copyPgnLabel = screen.getByText('Copy PGN');
+      const copyPgnButton = copyPgnLabel.parentElement?.querySelector('button');
+      
+      if (copyPgnButton) {
+        fireEvent.click(copyPgnButton);
+      }
+      
+      expect(defaultProps.copyVariantPGN).toHaveBeenCalledWith(defaultProps.selectedVariant);
+    });
+
+    it('should call copyVariantToRepertoire when Copy variant button is clicked', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const copyVariantLabel = screen.getByText('Copy variant');
+      const copyVariantButton = copyVariantLabel.parentElement?.querySelector('button');
+      
+      if (copyVariantButton) {
+        fireEvent.click(copyVariantButton);
+      }
+      
+      expect(defaultProps.copyVariantToRepertoire).toHaveBeenCalledWith(defaultProps.selectedVariant);
+    });
+  });
+
+  describe('Variant selection', () => {
+    it('should display selectedVariant name in selection button', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      expect(screen.getByText('Italian Game')).toBeInTheDocument();
+    });
+
+    it('should open variant selection dialog when selection button is clicked', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const selectionButton = screen.getByText('Italian Game');
+      fireEvent.click(selectionButton);
+      
+      expect(screen.getByText('Select Variant')).toBeInTheDocument();
+      expect(screen.getByText('Choose a single variant from current position')).toBeInTheDocument();
+    });
+
+    it('should call setSelectedVariant when variant is selected from dialog', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      const selectionButton = screen.getByText('Italian Game');
+      fireEvent.click(selectionButton);
+      
+      expect(screen.getByText('Select Variant')).toBeInTheDocument();
+    });
+  });
+
+  describe('Component integration', () => {
+    it('should render successfully with all required props', () => {
+      render(<VariantTree {...defaultProps} />);
+      
+      expect(screen.getByText('Italian Game')).toBeInTheDocument();
+    });
+
+    it('should not render action buttons when selectedVariant is null', () => {
+      const propsWithoutVariant = {
+        ...defaultProps,
+        selectedVariant: null,
+      };
+      
+      render(<VariantTree {...propsWithoutVariant} />);
+      
+      expect(screen.queryByText('Train')).not.toBeInTheDocument();
+      expect(screen.queryByText('Download')).not.toBeInTheDocument();
+    });
+
+    it('should handle empty variants array gracefully', () => {
+      const propsWithNoVariants = {
+        ...defaultProps,
+        variants: [],
+        selectedVariant: null,
+      };
+      
+      render(<VariantTree {...propsWithNoVariants} />);
+      
+      expect(screen.queryByText('Train')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Action consistency', () => {
+    it('should use consistent repertoire ID across all actions', () => {
+      const customRepertoireId = 'custom-repertoire-456';
+      const customProps = {
+        ...defaultProps,
+        repertoireId: customRepertoireId,
+      };
+      
+      render(<VariantTree {...customProps} />);
+      
+      const trainLabel = screen.getByText('Train');
+      const trainButton = trainLabel.parentElement?.querySelector('button');
+      
+      if (trainButton) {
+        fireEvent.click(trainButton);
+      }
+      
+      expect(mockGoToTrainRepertoire).toHaveBeenCalledWith(
+        customRepertoireId,
+        customProps.selectedVariant.fullName
+      );
+    });
+  });
+});

--- a/packages/frontend/src/components/design/chess/VariantTree/VariantTree.tsx
+++ b/packages/frontend/src/components/design/chess/VariantTree/VariantTree.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import React, { useMemo, useState } from "react";
 import { MoveVariantNode } from "../../../../models/VariantNode";
 import { Variant } from "../../../../models/chess.models";
 import { VariantMovementsPanel } from "./VariantMovementsPanel";
@@ -11,14 +10,15 @@ import {
   ClipboardIcon,
   ArrowDownTrayIcon,
   ClipboardDocumentListIcon,
+  AcademicCapIcon,
 } from "@heroicons/react/24/outline";
 import { TrashListIcon } from "../../../icons/TrashListIcon";
 import { BoardOrientation } from "@chess-opening-master/common";
+import { useNavigationUtils } from "../../../../utils/navigationUtils";
 
 interface VariantTreeProps {
   variants: Variant[];
   repertoireId: string;
-  currentNode: MoveVariantNode;
   orientation: BoardOrientation;
   deleteVariant: (variant: Variant) => void;
   copyVariantToRepertoire: (variant: Variant) => void;
@@ -30,12 +30,13 @@ interface VariantTreeProps {
   deleteMove: (move: MoveVariantNode) => void;
   goToMove: (move: MoveVariantNode) => void;
   currentMoveNode: MoveVariantNode;
+  selectedVariant: Variant | null;
+  setSelectedVariant: (variant: Variant | null) => void;
 }
 
 const VariantTree: React.FC<VariantTreeProps> = ({
   variants,
   repertoireId,
-  currentNode,
   deleteVariant,
   copyVariantToRepertoire,
   copyVariantsToRepertoire,
@@ -46,34 +47,20 @@ const VariantTree: React.FC<VariantTreeProps> = ({
   deleteMove,
   goToMove,
   currentMoveNode,
+  selectedVariant,
+  setSelectedVariant,
 }) => {
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const variantNameParam = params.get("variantName");
-
-  const isSelected = (node: MoveVariantNode) => node === currentNode;
-  const [selectedVariant, setSelectedVariant] = useState<Variant | undefined>(
-    variants[0]
-  );
+  const { goToTrainRepertoire } = useNavigationUtils();
   const [showSelectVariantDialog, setShowSelectVariantDialog] = useState(false);
-  useEffect(() => {
-    const pathVariant = variants.find(
-      (variant) =>
-        variant.name === variantNameParam ||
-        variant.fullName === variantNameParam
-    );
-    const defaultVariant = pathVariant ?? variants[0];
-
-    setSelectedVariant(
-      variants.find((variant) =>
-        variant.moves.some((move) => isSelected(move))
-      ) ?? defaultVariant
-    );
-  }, [variants, variantNameParam]);
 
   const variantActions = useMemo(
     () => () =>
       [
+        {
+          onClick: () => selectedVariant && goToTrainRepertoire(repertoireId, selectedVariant.fullName),
+          icon: <AcademicCapIcon className="h-5 w-5 text-accent" />,
+          label: "Train",
+        },
         {
           onClick: () => selectedVariant && downloadVariantPGN(selectedVariant),
           icon: <ArrowDownTrayIcon className="h-5 w-5 text-accent" />,
@@ -82,7 +69,7 @@ const VariantTree: React.FC<VariantTreeProps> = ({
         {
           onClick: () => selectedVariant && copyVariantPGN(selectedVariant),
           icon: <ClipboardIcon className="h-5 w-5 text-accent" />,
-          label: "Copy",
+          label: "Copy PGN",
         },
         {
           onClick: () =>
@@ -113,6 +100,9 @@ const VariantTree: React.FC<VariantTreeProps> = ({
       deleteVariant,
       deleteVariants,
       downloadVariantPGN,
+      copyVariantPGN,
+      goToTrainRepertoire,
+      repertoireId,
     ]
   );
 

--- a/packages/frontend/src/hooks/useVariantNavigation.test.ts
+++ b/packages/frontend/src/hooks/useVariantNavigation.test.ts
@@ -1,0 +1,98 @@
+import { renderHook, act } from '@testing-library/react';
+import { useVariantNavigation } from './useVariantNavigation';
+
+const mockNavigate = jest.fn();
+const mockSetSelectedVariant = jest.fn();
+const mockInitBoard = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(() => mockNavigate),
+  useLocation: jest.fn(() => ({
+    pathname: '/repertoire/test-id',
+    search: '',
+  })),
+}));
+
+jest.mock('../contexts/RepertoireContext', () => ({
+  useRepertoireContext: jest.fn(() => ({
+    setSelectedVariant: mockSetSelectedVariant,
+    initBoard: mockInitBoard,
+  })),
+}));
+
+describe('useVariantNavigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createMockVariant = (name: string, fullName: string) => ({
+    moves: [],
+    name,
+    fullName,
+    differentMoves: '',
+  });
+
+  describe('handleVariantChange', () => {
+    it('should set selected variant and initialize board when variant is provided', () => {
+      const { result } = renderHook(() => useVariantNavigation());
+      const variant = createMockVariant('Test Variant', 'Test Variant: Full Name');
+
+      act(() => {
+        result.current.handleVariantChange(variant);
+      });
+
+      expect(mockSetSelectedVariant).toHaveBeenCalledWith(variant);
+      expect(mockInitBoard).toHaveBeenCalled();
+    });
+
+    it('should update URL with variant name when variant is provided', () => {
+      const { result } = renderHook(() => useVariantNavigation());
+      const variant = createMockVariant('Test Variant', 'Test Variant: Full Name');
+
+      act(() => {
+        result.current.handleVariantChange(variant);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/repertoire/test-id?variantName=Test+Variant%3A+Full+Name',
+        { replace: true }
+      );
+    });
+
+    it('should remove variant name from URL when variant is null', () => {
+      const { result } = renderHook(() => useVariantNavigation());
+
+      act(() => {
+        result.current.handleVariantChange(null);
+      });
+
+      expect(mockSetSelectedVariant).toHaveBeenCalledWith(null);
+      expect(mockInitBoard).toHaveBeenCalled();
+    });
+
+    it('should handle special characters in variant names', () => {
+      const { result } = renderHook(() => useVariantNavigation());
+      const variant = createMockVariant("Queen's Gambit", "Queen's Gambit: Declined & Accepted");
+
+      act(() => {
+        result.current.handleVariantChange(variant);
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        "/repertoire/test-id?variantName=Queen%27s+Gambit%3A+Declined+%26+Accepted",
+        { replace: true }
+      );
+    });
+
+    it('should handle variant with empty fullName', () => {
+      const { result } = renderHook(() => useVariantNavigation());
+      const variant = createMockVariant('Test', '');
+
+      act(() => {
+        result.current.handleVariantChange(variant);
+      });
+
+      expect(mockSetSelectedVariant).toHaveBeenCalledWith(variant);
+    });
+  });
+});

--- a/packages/frontend/src/hooks/useVariantNavigation.ts
+++ b/packages/frontend/src/hooks/useVariantNavigation.ts
@@ -1,0 +1,26 @@
+import { useNavigate, useLocation } from "react-router-dom";
+import { useRepertoireContext } from "../contexts/RepertoireContext";
+import { Variant } from "../models/chess.models";
+
+export const useVariantNavigation = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setSelectedVariant, initBoard } = useRepertoireContext();
+
+  const handleVariantChange = (variant: Variant | null) => {
+    setSelectedVariant(variant);
+    initBoard();
+    
+    const currentParams = new URLSearchParams(location.search);
+    if (variant?.fullName) {
+      currentParams.set("variantName", variant.fullName);
+    } else {
+      currentParams.delete("variantName");
+    }
+    
+    const newUrl = `${location.pathname}?${currentParams.toString()}`;
+    navigate(newUrl, { replace: true });
+  };
+
+  return { handleVariantChange };
+};


### PR DESCRIPTION
This pull request refactors the chess repertoire navigation functionality by introducing a new `useVariantNavigation` hook and updating components to use it. Additionally, it improves the user interface by refining action labels and adding a new "Train" action for variants.

### Refactoring for navigation logic:
* Introduced a new `useVariantNavigation` hook to encapsulate logic for handling variant changes and URL updates, replacing inline logic in multiple components (`packages/frontend/src/hooks/useVariantNavigation.ts`).
* Updated `RepertoireInfo` and `VariantsInfo` components to use the new `useVariantNavigation` hook for handling variant changes (`packages/frontend/src/components/application/chess/board/RepertoireInfo.tsx`, [[1]](diffhunk://#diff-bc5d645535e50a2a7f01cf5d7597334a066c9a74a0ba2d74254af5642a1bf936L2-L11) [[2]](diffhunk://#diff-bc5d645535e50a2a7f01cf5d7597334a066c9a74a0ba2d74254af5642a1bf936L22-R23); `packages/frontend/src/components/application/chess/board/VariantsInfo.tsx`, [[3]](diffhunk://#diff-d0fe08609ec0e8beaaf2ef3da833b3898f6e62e86c8eee03e0fc637e50b8e299R7) [[4]](diffhunk://#diff-d0fe08609ec0e8beaaf2ef3da833b3898f6e62e86c8eee03e0fc637e50b8e299R18-R22) [[5]](diffhunk://#diff-d0fe08609ec0e8beaaf2ef3da833b3898f6e62e86c8eee03e0fc637e50b8e299R44-R45).

### Enhancements to user interface:
* Added a new "Train" action to the `RepertoireInfoPanel` and `VariantTree` components, allowing users to navigate to a training mode for a selected variant (`packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.tsx`, [[1]](diffhunk://#diff-4b917679e36f1a57ae3e60659107f39f0e323e96551f4d3a375e0455005b230dR85-R89); `packages/frontend/src/components/design/chess/VariantTree/VariantTree.tsx`, [[2]](diffhunk://#diff-3eff4b2a8ebaeb80c4c7f90cad7a45c534b322e4291ac61d38997cc28bbbd72dR50-R63).
* Updated the label for the "Copy" action to "Copy PGN" for clarity in both `RepertoireInfoPanel` and `VariantTree` components (`packages/frontend/src/components/design/chess/RepertoireInfoPanel/RepertoireInfoPanel.tsx`, [[1]](diffhunk://#diff-4b917679e36f1a57ae3e60659107f39f0e323e96551f4d3a375e0455005b230dL92-R98); `packages/frontend/src/components/design/chess/VariantTree/VariantTree.tsx`, [[2]](diffhunk://#diff-3eff4b2a8ebaeb80c4c7f90cad7a45c534b322e4291ac61d38997cc28bbbd72dL85-R72).

### Code cleanup and simplification:
* Removed unused imports and redundant state management in the `VariantTree` component, simplifying its implementation (`packages/frontend/src/components/design/chess/VariantTree/VariantTree.tsx`, [[1]](diffhunk://#diff-3eff4b2a8ebaeb80c4c7f90cad7a45c534b322e4291ac61d38997cc28bbbd72dL1-R1) [[2]](diffhunk://#diff-3eff4b2a8ebaeb80c4c7f90cad7a45c534b322e4291ac61d38997cc28bbbd72dR50-R63).
* Removed the inline `handleVariantChange` logic from components, centralizing it in the `useVariantNavigation` hook (`packages/frontend/src/components/application/chess/board/RepertoireInfo.tsx`, [[1]](diffhunk://#diff-bc5d645535e50a2a7f01cf5d7597334a066c9a74a0ba2d74254af5642a1bf936L22-R23); `packages/frontend/src/components/application/chess/board/VariantsInfo.tsx`, [[2]](diffhunk://#diff-d0fe08609ec0e8beaaf2ef3da833b3898f6e62e86c8eee03e0fc637e50b8e299R18-R22).