### PR TITLE
Enhance focus mode visuals across edit and training views

### DIFF
--- a/packages/frontend/src/contexts/RepertoireContext.tsx
+++ b/packages/frontend/src/contexts/RepertoireContext.tsx
@@ -91,15 +91,17 @@ export const RepertoireContextProvider: React.FC<
   const { showSelectNextMoveDialog } = useDialogContext();
 
   useEffect(() => {
-    const intervalSave = setInterval(() => {
-      if (hasChanges) {
-        saveRepertory();
-        setHasChanges(false);
-      }
-    }, 500);
+    if (!hasChanges) {
+      return;
+    }
 
-    return () => clearInterval(intervalSave);
-  }, [hasChanges]);
+    const debounceSave = setTimeout(() => {
+      saveRepertory();
+      setHasChanges(false);
+    }, 1000);
+
+    return () => clearTimeout(debounceSave);
+  }, [hasChanges, saveRepertory]);
 
   const [moveHistory, setMoveHistory] = useState<MoveVariantNode>(
     initialMoves

--- a/packages/frontend/src/pages/repertoires/EditRepertoirePage/EditRepertoireViewContainer.tsx
+++ b/packages/frontend/src/pages/repertoires/EditRepertoirePage/EditRepertoireViewContainer.tsx
@@ -12,6 +12,8 @@ import {
   ChatBubbleBottomCenterTextIcon,
   ComputerDesktopIcon,
   PresentationChartLineIcon,
+  EyeIcon,
+  EyeSlashIcon,
 } from "@heroicons/react/24/outline";
 import SaveIcon from "../../../components/icons/SaveIcon";
 import VariantsIcon from "../../../components/icons/VariantsIcon";
@@ -28,6 +30,7 @@ type FooterSection = "variants" | "comments" | "statistics" | "stockfish";
 const EditRepertoireViewContainer: React.FC = () => {
   const navigate = useNavigate();
   const [panelSelected, setPanelSelected] = useState<FooterSection>("variants");
+  const [isFocusMode, setIsFocusMode] = useState(false);
 
   const { 
     repertoireId, 
@@ -98,6 +101,11 @@ const EditRepertoireViewContainer: React.FC = () => {
       onClick: saveRepertory,
     });
     addIconHeader({
+      key: "focusMode",
+      icon: isFocusMode ? <EyeSlashIcon /> : <EyeIcon />,
+      onClick: () => setIsFocusMode((prev) => !prev),
+    });
+    addIconHeader({
       key: "moreOptions",
       icon: <EllipsisVerticalIcon />,
       onClick: toggleMenuHeader,
@@ -106,36 +114,41 @@ const EditRepertoireViewContainer: React.FC = () => {
     return () => {
       removeIconHeader("trainRepertoire");
       removeIconHeader("saveRepertoire");
+      removeIconHeader("focusMode");
       removeIconHeader("moreOptions");
     };
-  }, [navigate, repertoireId, saveRepertory, getPgn, toggleMenu]);
+  }, [navigate, repertoireId, saveRepertory, getPgn, toggleMenu, isFocusMode]);
 
   useEffect(() => {
-    setIsVisible(true);
-    addIconFooter({
-      key: "variants",
-      label: "Variants",
-      icon: <VariantsIcon className="h-6 w-6" />,
-      onClick: () => setPanelSelected("variants"),
-    });
-    addIconFooter({
-      key: "comments",
-      label: "Comments",
-      icon: <ChatBubbleBottomCenterTextIcon className="h-6 w-6" />,
-      onClick: () => setPanelSelected("comments"),
-    });
-    addIconFooter({
-      key: "statistics",
-      label: "Statistics",
-      icon: <PresentationChartLineIcon className="h-6 w-6" />,
-      onClick: () => setPanelSelected("statistics"),
-    });
-    addIconFooter({
-      key: "stockfish",
-      label: "Stockfish",
-      icon: <ComputerDesktopIcon className="h-6 w-6" />,
-      onClick: () => setPanelSelected("stockfish"),
-    });
+    if (!isFocusMode) {
+      setIsVisible(true);
+      addIconFooter({
+        key: "variants",
+        label: "Variants",
+        icon: <VariantsIcon className="h-6 w-6" />,
+        onClick: () => setPanelSelected("variants"),
+      });
+      addIconFooter({
+        key: "comments",
+        label: "Comments",
+        icon: <ChatBubbleBottomCenterTextIcon className="h-6 w-6" />,
+        onClick: () => setPanelSelected("comments"),
+      });
+      addIconFooter({
+        key: "statistics",
+        label: "Statistics",
+        icon: <PresentationChartLineIcon className="h-6 w-6" />,
+        onClick: () => setPanelSelected("statistics"),
+      });
+      addIconFooter({
+        key: "stockfish",
+        label: "Stockfish",
+        icon: <ComputerDesktopIcon className="h-6 w-6" />,
+        onClick: () => setPanelSelected("stockfish"),
+      });
+    } else {
+      setIsVisible(false);
+    }
 
     return () => {
       setIsVisible(false);
@@ -144,23 +157,48 @@ const EditRepertoireViewContainer: React.FC = () => {
       removeIconFooter("statistics");
       removeIconFooter("stockfish");
     };
-  }, []);
+  }, [addIconFooter, removeIconFooter, setIsVisible, isFocusMode]);
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-12 w-full gap-4 bg-background text-textLight h-full">
-      <div className="col-span-12 sm:col-span-6  flex flex-col justify-center items-center">
-        <div className="flex justify-center w-full p-1 sm:p-4">
+    <div
+      className={`grid grid-cols-1 w-full gap-4 text-textLight h-full ${
+        isFocusMode ? "sm:grid-cols-1 bg-slate-950/70" : "sm:grid-cols-12 bg-background"
+      }`}
+    >
+      <div
+        className={`col-span-12 flex flex-col justify-center items-center ${
+          isFocusMode ? "" : "sm:col-span-6"
+        }`}
+      >
+        <div className="flex flex-col items-center w-full gap-2 p-1 sm:p-4">
+          {isFocusMode && (
+            <span className="rounded-full border border-amber-400/60 bg-amber-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-amber-200">
+              Focus Mode
+            </span>
+          )}
           <h1 className="text-base sm:text-2xl font-bold">{repertoireName}</h1>
+          <p className="text-xs sm:text-sm text-textLight/70">
+            {isFocusMode
+              ? "Distractions off — concentrate on the main line."
+              : "Edit moves, comments, and variants."}
+          </p>
         </div>
-        <div className="flex justify-center w-full sm:p-4 lg:max-h-[60vh] lg:max-w-[60vh]">
-          <BoardContainer />
+        <div className="flex justify-center w-full sm:p-4">
+          <div
+            className={`rounded-2xl border border-secondary/60 bg-gray-900/60 p-3 shadow-lg ${
+              isFocusMode ? "lg:max-w-[75vh] lg:max-h-[75vh]" : "lg:max-h-[60vh] lg:max-w-[60vh]"
+            }`}
+          >
+            <BoardContainer />
+          </div>
         </div>
         <div className="flex justify-center w-full p-1 sm:p-4">
           <BoardActionsContainer />
         </div>
       </div>
 
-      <div className="sm:hidden col-span-12 sm:col-span-6 flex flex-col items-start overflow-auto border border-secondary rounded bg-gray-800">
+      {!isFocusMode && (
+        <div className="sm:hidden col-span-12 sm:col-span-6 flex flex-col items-start overflow-auto border border-secondary/70 rounded bg-gray-800/90 shadow-md">
         {panelSelected === "variants" && <VariantsInfo />}
         {panelSelected === "comments" && <BoardCommentContainer />}
         {panelSelected === "statistics" && (
@@ -169,11 +207,14 @@ const EditRepertoireViewContainer: React.FC = () => {
         {panelSelected === "stockfish" && (
           <StockfishPanel fen={chess.fen()} numLines={3} />
         )}
-      </div>
+        </div>
+      )}
 
-      <div className="hidden sm:flex sm:col-span-6 flex-col items-start overflow-auto border border-secondary rounded bg-gray-800">
-        <RepertoireInfo />
-      </div>
+      {!isFocusMode && (
+        <div className="hidden sm:flex sm:col-span-6 flex-col items-start overflow-auto border border-secondary/70 rounded bg-gray-800/90 shadow-md">
+          <RepertoireInfo />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/pages/repertoires/TrainRepertoirePage/TrainRepertoireViewContainer.tsx
+++ b/packages/frontend/src/pages/repertoires/TrainRepertoirePage/TrainRepertoireViewContainer.tsx
@@ -13,6 +13,8 @@ import {
   PencilIcon,
   ChatBubbleLeftIcon,
   ClipboardDocumentIcon,
+  EyeIcon,
+  EyeSlashIcon,
 } from "@heroicons/react/24/outline";
 import TrainInfo from "../../../components/design/chess/train/TrainInfo";
 import HelpInfo from "../../../components/design/chess/train/HelpInfo";
@@ -24,6 +26,7 @@ const TrainRepertoireViewContainer: React.FC = () => {
   const [panelSelected, setPanelSelected] = React.useState<
     "info" | "help" | "trainComments"
   >("info");
+  const [isFocusMode, setIsFocusMode] = React.useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const { repertoireId, repertoireName, currentMoveNode, orientation, variants, updateComment } =
@@ -99,6 +102,11 @@ const TrainRepertoireViewContainer: React.FC = () => {
           navigate(editUrl);
         },
       },
+      {
+        key: "focusMode",
+        icon: isFocusMode ? <EyeSlashIcon /> : <EyeIcon />,
+        onClick: () => setIsFocusMode((prev) => !prev),
+      },
     ];
 
     headerIcons.forEach(({ key, icon, onClick }) => {
@@ -120,10 +128,15 @@ const TrainRepertoireViewContainer: React.FC = () => {
     navigate,
     repertoireId,
     variants,
+    isFocusMode,
   ]);
 
   useEffect(() => {
-    setIsVisible(true);
+    if (!isFocusMode) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
     const footerIcons = [
       {
         key: "info",
@@ -145,9 +158,11 @@ const TrainRepertoireViewContainer: React.FC = () => {
       },
     ];
 
-    footerIcons.forEach(({ key, label, icon, onClick }) => {
-      addIconFooter({ key, label, icon, onClick });
-    });
+    if (!isFocusMode) {
+      footerIcons.forEach(({ key, label, icon, onClick }) => {
+        addIconFooter({ key, label, icon, onClick });
+      });
+    }
 
     return () => {
       setIsVisible(false);
@@ -155,7 +170,7 @@ const TrainRepertoireViewContainer: React.FC = () => {
         removeIconFooter(key);
       });
     };
-  }, [addIconFooter, removeIconFooter, setIsVisible]);
+  }, [addIconFooter, removeIconFooter, setIsVisible, isFocusMode]);
 
   const renderPanelContent = useMemo(
     () => (
@@ -206,25 +221,53 @@ const TrainRepertoireViewContainer: React.FC = () => {
       lastTrainVariant,
       allowedMoves,
       repertoireId,
+      orientation,
+      updateComment,
     ]
   );
 
   return (
-    <div className="container mx-auto p-1 sm:p-4 h-full bg-background text-textLight">
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 h-full">
+    <div
+      className={`container mx-auto p-1 sm:p-4 h-full text-textLight ${
+        isFocusMode ? "bg-slate-950/70" : "bg-background"
+      }`}
+    >
+      <div
+        className={`grid grid-cols-1 gap-4 h-full ${
+          isFocusMode ? "sm:grid-cols-1" : "sm:grid-cols-2"
+        }`}
+      >
         <div className="flex flex-col items-center justify-center h-full">
-          <div className="flex justify-center mb-1 sm:mb-4">
+          <div className="flex flex-col items-center gap-2 mb-1 sm:mb-4">
+            {isFocusMode && (
+              <span className="rounded-full border border-emerald-400/60 bg-emerald-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-wider text-emerald-200">
+                Focus Mode
+              </span>
+            )}
             <h5 className="text-base sm:text-xl font-bold text-textLight">
               Training {repertoireName}
             </h5>
+            <p className="text-xs sm:text-sm text-textLight/70">
+              {isFocusMode
+                ? "Stay in the zone — panel distractions hidden."
+                : "Review moves, hints, and comments while training."}
+            </p>
           </div>
-          <div className="flex justify-center w-full max-w-md">
-            <BoardContainer isTraining={true} />
+          <div className="flex justify-center w-full">
+            <div
+              className={`rounded-2xl border border-secondary/60 bg-gray-900/60 p-3 shadow-lg ${
+                isFocusMode ? "max-w-2xl" : "max-w-md"
+              }`}
+            >
+              <BoardContainer isTraining={true} />
+            </div>
           </div>
         </div>
-        <div className="flex flex-col items-start h-full overflow-auto border border-secondary rounded bg-gray-800">
-          {renderPanelContent}
-        </div>
+        {!isFocusMode && (
+          <div className="flex flex-col items-start h-full overflow-auto border border-secondary/70 rounded bg-gray-800/90 shadow-md">
+            {renderPanelContent}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/doc/technical-audit-es.md
+++ b/src/doc/technical-audit-es.md
@@ -1,0 +1,85 @@
+# Auditoría técnica y propuestas de mejora (ES)
+
+> Documento complementario con foco explícito en **diseño** y **funcionalidad**.
+
+## Diagnóstico rápido de UI/UX actual
+
+- El tablero se integra vía `react-chessboard`, librería sin mantenimiento activo según la documentación del repositorio, lo que incrementa el riesgo de deuda técnica y frena mejoras visuales o de accesibilidad.【F:Readme.md†L116-L119】
+- El flujo de edición y entrenamiento está centrado en la interacción directa con el tablero y el árbol de variantes; hay potencial para mejorar **memorización** y **recall activo** sin romper funcionalidad existente.
+
+## Informe de mejoras (Diseño)
+
+### 1) Modo de estudio guiado (Focus Mode)
+**Objetivo:** minimizar ruido visual y priorizar la memorización.
+- Panel izquierdo: árbol colapsable de variantes con breadcrumb de la línea activa.
+- Panel derecho: comentarios de posición + tips tácticos (según FEN).
+- Toggle para mostrar/ocultar Stockfish y estadísticas (reduce sobrecarga cognitiva).
+
+**Beneficios tangibles:** mejora la retención por repetición activa y reduce la fatiga visual.
+
+### 2) Sistema de anotaciones visuales
+**Objetivo:** facilitar la memorización espacial.
+- Paletas de colores para flechas/círculos por propósito (planes, amenazas, ideas).
+- Historial de anotaciones por variante (no solo por nodo actual).
+
+**Beneficios:** refuerza patrones de planes y estructura de peones.
+
+### 3) Accesibilidad y consistencia visual
+**Objetivo:** mejorar legibilidad y uso continuo.
+- Contraste mejorado para textos y estados (errores, aciertos, review).
+- Tipografía monoespaciada opcional para SAN/PGN (reduce errores de lectura).
+
+**Beneficios:** sesiones más largas sin fatiga.
+
+## Informe de mejoras (Funcionalidad)
+
+### 1) Sistema de repetición espaciada (SM-2)
+**Objetivo:** priorizar variantes en función del olvido real.
+- Guardar `easiness`, `interval`, `repetitions` por variante.
+- Integrar el selector de paths con estas métricas.
+
+**Beneficios:** aprendizaje más eficiente y con menor tiempo total de entrenamiento.
+
+### 2) Modo “errores típicos”
+**Objetivo:** entrenar variantes con distracciones reales.
+- Permitir registrar movimientos erróneos recurrentes.
+- En entrenamiento, introducirlos como opciones para reforzar el reconocimiento.
+
+**Beneficios:** disminuye errores habituales en partidas reales.
+
+### 3) Métricas de progreso y consistencia
+**Objetivo:** feedback continuo y motivacional.
+- Dashboard con “racha de estudio”, “errores por apertura” y “última revisión”.
+- Resumen semanal/mensual para detectar estancamientos.
+
+**Beneficios:** visibilidad clara del avance real.
+
+## Por dónde empezar (prioridad recomendada)
+
+1) **Diseño: Focus Mode (modo de estudio guiado)**  
+   - Impacto inmediato en memorización y reducción de fatiga visual.  
+   - Riesgo bajo porque no toca lógica de variantes ni backend.
+
+2) **Funcionalidad: métricas de progreso**  
+   - Aporta valor tangible con datos ya existentes.  
+   - No requiere cambios profundos en selección de variantes.
+
+3) **Funcionalidad avanzada: SM-2**  
+   - Potencia el aprendizaje, pero requiere cambios en datos y selector.  
+   - Conviene implementarlo cuando la UI/UX esté estable.
+
+## Plan de acción (alto nivel)
+
+1) **Diseño:** crear prototipos ligeros del Focus Mode y panel de progreso.
+2) **Backend:** definir schema de SM-2 y migración incremental.
+3) **Frontend:** integrar el selector de paths con SM-2 y nueva UI.
+4) **Testing:** añadir unit + integración para no romper el motor de variantes.
+
+## Estrategia de testing propuesta
+
+- **Unitarios**
+  - Selector de paths con SM-2.
+  - Persistencia de métricas por variante.
+- **Integración**
+  - Flujo completo: entrenamiento → actualización de métricas → nuevo path.
+  - Validar que comentarios y árboles no se rompan.


### PR DESCRIPTION
### Motivation
- Make Focus Mode visually clearer and more useful by reducing visual noise and improving hierarchy around the board.
- Improve the perceived polish of edit and training flows by adding subtle card styling, banners, and helper text to guide the user when focusing.

### Description
- Add a `focusMode` header toggle (using `EyeIcon` / `EyeSlashIcon`) to both the edit view and training view and wire it to local `isFocusMode` state (`EditRepertoireViewContainer.tsx`, `TrainRepertoireViewContainer.tsx`).
- Hide footer icons and side panels when Focus Mode is enabled by conditionally calling `setIsVisible` and conditionally rendering the panel columns, and include `isFocusMode` in relevant effect dependency arrays.
- Improve visuals by rendering a focus banner and helper text, wrapping `BoardContainer` in a rounded, bordered card with `shadow-lg`, and refining background classes to `bg-slate-950/70` in focus state (changes in `EditRepertoireViewContainer.tsx` and `TrainRepertoireViewContainer.tsx`).
- Replace the interval-based autosave with a 1s debounce in `RepertoireContext.tsx` so `saveRepertory()` runs after changes settle, and add `saveRepertory` to the effect dependencies.

### Testing
- Attempted to start the frontend dev server with `yarn --cwd packages/frontend start:dev`, which failed with an error stating the workspace is missing from the lockfile, so the app was not launched for visual verification.
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a89a3da408332bd027c77425579d4)