### PR TITLE
Add unified game imports, opening mapping, and training plan workflows

### DIFF
--- a/docs/specs/game-imports-openings-training-plan.md
+++ b/docs/specs/game-imports-openings-training-plan.md
@@ -1,0 +1,123 @@
+# Game Imports, Opening Mapping, and Training Plan Spec
+
+## Goals
+- Link Lichess and Chess.com accounts.
+- Import games with initial and incremental sync.
+- Support manual PGN paste and `.pgn` upload with multi-game parsing.
+- Detect openings and line signatures.
+- Map detected lines to Saved Openings repertoires.
+- Provide game statistics, lines-to-study candidates, and a prioritized training plan.
+
+## User Stories
+- As a user, I can connect/disconnect Lichess and Chess.com accounts from one place.
+- As a user, I can run sync repeatedly and import only new games.
+- As a user, I can paste a single PGN or a bulk PGN file and import all games.
+- As a user, I can tag games and optionally assign a tournament/training group.
+- As a user, I can see opening-level performance and line-level weaknesses.
+- As a user, I can generate a ranked training plan and mark items done.
+
+## UX and Information Architecture
+- New page: `/games` as the central Insights area.
+- Sections:
+  - Linked Accounts (connect/disconnect/sync status)
+  - Manual PGN Import (paste, upload, tags, tournament group)
+  - Stats Summary (W/L/D, win rate, game count)
+  - Training Plan (ordered items with reason and effort)
+
+## Architecture
+- One ingestion pipeline for all sources:
+  - Provider fetch/parse
+  - Normalize
+  - Deduplicate
+  - Detect opening + line key
+  - Map to repertoire
+  - Persist and aggregate stats
+  - Generate training plan
+- Provider layer:
+  - `LichessProvider`
+  - `ChessComProvider`
+  - `ManualPgnProvider`
+
+## Data Model
+- `linkedGameAccounts`
+  - `userId`, `provider`, `username`, `tokenEncrypted`, `connectedAt`, `lastSyncAt`, `status`, `lastError`
+- `importedGames`
+  - `userId`, `source`, `providerGameId`, `dedupeKey`, player/rating metadata, result, time control
+  - `pgn`, `movesSan`, `openingDetection`, `openingMapping`, tags, tournament group
+- `trainingPlans`
+  - `userId`, generated metadata, weights, ordered items
+
+## API
+- `GET /games/accounts`
+- `POST /games/accounts`
+- `DELETE /games/accounts/:provider`
+- `POST /games/imports`
+- `GET /games/imports`
+- `GET /games/stats`
+- `POST /games/training-plan`
+- `GET /games/training-plan`
+- `PATCH /games/training-plan/:planId/items/:lineKey`
+
+## Opening Detection
+- Priority 1: provider PGN ECO/Openings tags.
+- Priority 2: line signature from SAN moves up to 12 plies.
+- Stable `lineKey` hash generated from normalized move line.
+- Confidence score stored with fallback signature.
+
+## Mapping to Saved Openings
+- Heuristics:
+  1. ECO exact
+  2. Move-prefix overlap with repertoire main line
+  3. Fuzzy opening name match
+  4. Tag overlap
+- Auto-map threshold: confidence `>= 0.75`.
+- Lower confidence flags manual review.
+
+## Statistics
+- Filters:
+  - Date range
+  - Time control bucket
+  - Rated-only
+  - Color
+  - Opponent rating band
+  - Tournament group
+- Metrics:
+  - W/L/D
+  - Win rate
+  - Top openings
+  - Lines to study candidates with sample games and suggested tasks
+
+## Lines to Study
+- Candidate line conditions:
+  - Underperformance
+  - Frequency
+  - Recency
+  - Deviation/manual-review rate
+- Output includes tasks:
+  - Review main line
+  - Drill to ply N
+  - Constrained practice games
+
+## Training Plan Scoring
+- Default formula:
+  - `priority = w1*frequency + w2*problem + w3*recency + w4*repertoireGap + w5*deviationRate`
+- Defaults:
+  - `w1=0.25`, `w2=0.30`, `w3=0.15`, `w4=0.20`, `w5=0.10`
+- Items include reasons, effort estimate, tasks, done-state.
+
+## Error Handling and Safety
+- Provider sync errors recorded per account status.
+- API returns clear user-facing messages.
+- Provider tokens encrypted at rest.
+- No token or PGN logging in service/controller path.
+
+## Tests
+- Unit tests for PGN splitting/parsing, opening detection, and dedupe key stability.
+- Service-level tests for training-plan generation and mapping can be expanded next iteration.
+
+## Acceptance Criteria
+- Users can connect accounts and run syncs.
+- Users can manually import single/multi-game PGN via paste or upload.
+- Imported games are deduplicated across sources.
+- Opening detection and mapping metadata persist per game.
+- Users can view summary stats, lines-to-study, and generate/track training plan items.

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -6,6 +6,7 @@ import studiesRouter from "./routes/studies";
 import paths from "./routes/paths";
 import positionsRouter from "./routes/positionComments";
 import authRouter from "./routes/auth";
+import gamesRouter from "./routes/games";
 import errorHandler from "./middleware/errorHandler";
 import { authMiddleware } from "./middleware/auth";
 import { ensureDefaultUserAndMigrateData } from "./services/authService";
@@ -56,6 +57,7 @@ app.use("/repertoires", repertoiresRouter);
 app.use("/studies", studiesRouter);
 app.use("/paths", paths);
 app.use("/positions", positionsRouter);
+app.use("/games", gamesRouter);
 
 app.use(errorHandler);
 

--- a/packages/backend/src/controllers/gamesController.ts
+++ b/packages/backend/src/controllers/gamesController.ts
@@ -1,0 +1,133 @@
+import { NextFunction, Request, Response } from "express";
+import { getRequestUserId } from "../utils/requestUser";
+import {
+  disconnectLinkedAccount,
+  generateTrainingPlan,
+  getGamesStats,
+  getLatestTrainingPlan,
+  importGamesForUser,
+  listImportedGames,
+  listLinkedAccounts,
+  markTrainingPlanItemDone,
+  upsertLinkedAccount,
+} from "../services/games/gameImportService";
+
+export async function getLinkedAccounts(req: Request, res: Response, next: NextFunction) {
+  try {
+    const accounts = await listLinkedAccounts(getRequestUserId(req));
+    res.json(accounts);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function postLinkedAccount(req: Request, res: Response, next: NextFunction) {
+  try {
+    const provider = req.body?.provider;
+    const username = typeof req.body?.username === "string" ? req.body.username.trim() : "";
+    const token = typeof req.body?.token === "string" ? req.body.token.trim() : undefined;
+    if ((provider !== "lichess" && provider !== "chesscom") || !username) {
+      return res.status(400).json({ message: "provider and username are required" });
+    }
+    const account = await upsertLinkedAccount(getRequestUserId(req), provider, username, token);
+    res.status(201).json(account);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function deleteLinkedAccount(req: Request, res: Response, next: NextFunction) {
+  try {
+    const provider = req.params.provider;
+    if (provider !== "lichess" && provider !== "chesscom") {
+      return res.status(400).json({ message: "invalid provider" });
+    }
+    await disconnectLinkedAccount(getRequestUserId(req), provider);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function postImportGames(req: Request, res: Response, next: NextFunction) {
+  try {
+    const source = req.body?.source;
+    if (source !== "lichess" && source !== "chesscom" && source !== "manual") {
+      return res.status(400).json({ message: "invalid source" });
+    }
+    const summary = await importGamesForUser(getRequestUserId(req), {
+      source,
+      username: typeof req.body?.username === "string" ? req.body.username.trim() : undefined,
+      token: typeof req.body?.token === "string" ? req.body.token.trim() : undefined,
+      pgn: typeof req.body?.pgn === "string" ? req.body.pgn : undefined,
+      tournamentGroup: typeof req.body?.tournamentGroup === "string" ? req.body.tournamentGroup : undefined,
+      tags: Array.isArray(req.body?.tags) ? req.body.tags.filter((tag: unknown) => typeof tag === "string") : undefined,
+    });
+    res.status(200).json(summary);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getImportedGames(req: Request, res: Response, next: NextFunction) {
+  try {
+    const limit = Number(req.query.limit);
+    const games = await listImportedGames(getRequestUserId(req), Number.isFinite(limit) ? limit : 100);
+    res.json(games);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getGamesStatsSummary(req: Request, res: Response, next: NextFunction) {
+  try {
+    const stats = await getGamesStats(getRequestUserId(req), {
+      dateFrom: typeof req.query.dateFrom === "string" ? req.query.dateFrom : undefined,
+      dateTo: typeof req.query.dateTo === "string" ? req.query.dateTo : undefined,
+      timeControlBucket:
+        req.query.timeControlBucket === "bullet" || req.query.timeControlBucket === "blitz" || req.query.timeControlBucket === "rapid" || req.query.timeControlBucket === "classical"
+          ? req.query.timeControlBucket
+          : undefined,
+      ratedOnly: req.query.ratedOnly === "true",
+      color: req.query.color === "white" || req.query.color === "black" ? req.query.color : undefined,
+      opponentRatingBand: typeof req.query.opponentRatingBand === "string" ? req.query.opponentRatingBand : undefined,
+      tournamentGroup: typeof req.query.tournamentGroup === "string" ? req.query.tournamentGroup : undefined,
+    });
+    res.json(stats);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function postGenerateTrainingPlan(req: Request, res: Response, next: NextFunction) {
+  try {
+    const plan = await generateTrainingPlan(getRequestUserId(req), req.body?.weights);
+    res.status(201).json(plan);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function getTrainingPlan(req: Request, res: Response, next: NextFunction) {
+  try {
+    const plan = await getLatestTrainingPlan(getRequestUserId(req));
+    if (!plan) {
+      return res.status(404).json({ message: "No training plan generated" });
+    }
+    res.json(plan);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function patchTrainingPlanItem(req: Request, res: Response, next: NextFunction) {
+  try {
+    const planId = req.params.planId;
+    const lineKey = req.params.lineKey;
+    const done = Boolean(req.body?.done);
+    await markTrainingPlanItemDone(getRequestUserId(req), planId, lineKey, done);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/packages/backend/src/db/indexes.ts
+++ b/packages/backend/src/db/indexes.ts
@@ -172,5 +172,10 @@ export async function ensureDatabaseIndexes(db: Db): Promise<void> {
     createIndexSafely(db, "variantReviewHistory", { userId: 1, reviewedAt: -1 }),
     createIndexSafely(db, "variantReviewHistory", { userId: 1, reviewedDayKey: 1 }),
     createIndexSafely(db, "variantReviewHistory", { userId: 1, openingName: 1, orientation: 1 }),
+    createIndexSafely(db, "linkedGameAccounts", { userId: 1, provider: 1 }, { unique: true }),
+    createIndexSafely(db, "importedGames", { userId: 1, dedupeKey: 1 }, { unique: true }),
+    createIndexSafely(db, "importedGames", { userId: 1, playedAt: -1 }),
+    createIndexSafely(db, "importedGames", { userId: 1, "openingDetection.lineKey": 1 }),
+    createIndexSafely(db, "trainingPlans", { userId: 1, generatedAtDate: -1 }),
   ]);
 }

--- a/packages/backend/src/db/test/indexes.spec.ts
+++ b/packages/backend/src/db/test/indexes.spec.ts
@@ -30,6 +30,9 @@ describe("ensureDatabaseIndexes", () => {
   let studiesCollection: MockCollection;
   let variantsInfoCollection: MockCollection;
   let variantReviewHistoryCollection: MockCollection;
+  let linkedGameAccountsCollection: MockCollection;
+  let importedGamesCollection: MockCollection;
+  let trainingPlansCollection: MockCollection;
   let mockDb: MockDb;
 
   beforeEach(() => {
@@ -40,6 +43,9 @@ describe("ensureDatabaseIndexes", () => {
     studiesCollection = createCollection();
     variantsInfoCollection = createCollection();
     variantReviewHistoryCollection = createCollection();
+    linkedGameAccountsCollection = createCollection();
+    importedGamesCollection = createCollection();
+    trainingPlansCollection = createCollection();
 
     mockDb = {
       collection: jest.fn((name: string) => {
@@ -50,6 +56,9 @@ describe("ensureDatabaseIndexes", () => {
         if (name === "studies") return studiesCollection;
         if (name === "variantsInfo") return variantsInfoCollection;
         if (name === "variantReviewHistory") return variantReviewHistoryCollection;
+        if (name === "linkedGameAccounts") return linkedGameAccountsCollection;
+        if (name === "importedGames") return importedGamesCollection;
+        if (name === "trainingPlans") return trainingPlansCollection;
         throw new Error(`Unexpected collection ${name}`);
       }),
     };

--- a/packages/backend/src/models/GameImport.ts
+++ b/packages/backend/src/models/GameImport.ts
@@ -1,0 +1,50 @@
+import { ObjectId } from "mongodb";
+import { BoardOrientation, GameSource, LinkedAccountProvider, OpeningDetection, OpeningMapping, SyncStatus, TrainingPlan, TrainingPlanWeights } from "@chess-opening-master/common";
+
+export interface LinkedGameAccountDocument {
+  userId: string;
+  provider: LinkedAccountProvider;
+  username: string;
+  tokenEncrypted?: string;
+  connectedAt: Date;
+  lastSyncAt?: Date;
+  status: SyncStatus;
+  lastError?: string;
+}
+
+export interface ImportedGameDocument {
+  _id?: ObjectId;
+  userId: string;
+  source: GameSource;
+  providerGameId?: string;
+  dedupeKey: string;
+  white: string;
+  black: string;
+  whiteRating?: number;
+  blackRating?: number;
+  result: "1-0" | "0-1" | "1/2-1/2" | "*";
+  timeControl?: string;
+  rated?: boolean;
+  playedAt?: Date;
+  pgn: string;
+  movesSan: string[];
+  orientation?: BoardOrientation;
+  tournamentGroup?: string;
+  tags?: string[];
+  openingDetection: OpeningDetection;
+  openingMapping: OpeningMapping;
+  createdAt: Date;
+}
+
+export interface TrainingPlanDocument extends TrainingPlan {
+  userId: string;
+  generatedAtDate: Date;
+}
+
+export const DEFAULT_TRAINING_PLAN_WEIGHTS: TrainingPlanWeights = {
+  frequency: 0.25,
+  problem: 0.3,
+  recency: 0.15,
+  repertoireGap: 0.2,
+  deviationRate: 0.1,
+};

--- a/packages/backend/src/routes/games.ts
+++ b/packages/backend/src/routes/games.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import {
+  deleteLinkedAccount,
+  getGamesStatsSummary,
+  getImportedGames,
+  getLinkedAccounts,
+  getTrainingPlan,
+  patchTrainingPlanItem,
+  postGenerateTrainingPlan,
+  postImportGames,
+  postLinkedAccount,
+} from "../controllers/gamesController";
+
+const router = Router();
+
+router.get("/accounts", getLinkedAccounts);
+router.post("/accounts", postLinkedAccount);
+router.delete("/accounts/:provider", deleteLinkedAccount);
+router.post("/imports", postImportGames);
+router.get("/imports", getImportedGames);
+router.get("/stats", getGamesStatsSummary);
+router.post("/training-plan", postGenerateTrainingPlan);
+router.get("/training-plan", getTrainingPlan);
+router.patch("/training-plan/:planId/items/:lineKey", patchTrainingPlanItem);
+
+export default router;

--- a/packages/backend/src/services/games/gameImportService.ts
+++ b/packages/backend/src/services/games/gameImportService.ts
@@ -1,0 +1,508 @@
+import { ObjectId } from "mongodb";
+import {
+  GameStatsFilters,
+  GamesStatsSummary,
+  ImportSummary,
+  ImportedGame,
+  LinkedGameAccount,
+  LineStudyCandidate,
+  OpeningMapping,
+  TrainingPlan,
+  TrainingPlanWeights,
+} from "@chess-opening-master/common";
+import { getDB } from "../../db/mongo";
+import { DEFAULT_TRAINING_PLAN_WEIGHTS, ImportedGameDocument, LinkedGameAccountDocument, TrainingPlanDocument } from "../../models/GameImport";
+import { decryptSecret, encryptSecret } from "./security";
+import { chessComProvider } from "./providers/chessComProvider";
+import { lichessProvider } from "./providers/lichessProvider";
+import { manualPgnProvider } from "./providers/manualPgnProvider";
+import { buildFallbackDedupeKey, detectOpening, inferOrientation, toNormalizedResult } from "./pgnProcessing";
+
+interface ProviderImportInput {
+  source: "lichess" | "chesscom" | "manual";
+  username?: string;
+  token?: string;
+  pgn?: string;
+  tournamentGroup?: string;
+  tags?: string[];
+}
+
+const mapAccount = (doc: LinkedGameAccountDocument & { _id: ObjectId }): LinkedGameAccount => ({
+  id: doc._id.toString(),
+  provider: doc.provider,
+  username: doc.username,
+  connectedAt: doc.connectedAt.toISOString(),
+  lastSyncAt: doc.lastSyncAt?.toISOString(),
+  status: doc.status,
+  lastError: doc.lastError,
+});
+
+const mapImportedGame = (doc: ImportedGameDocument & { _id: ObjectId }): ImportedGame => ({
+  id: doc._id.toString(),
+  source: doc.source,
+  providerGameId: doc.providerGameId,
+  white: doc.white,
+  black: doc.black,
+  whiteRating: doc.whiteRating,
+  blackRating: doc.blackRating,
+  result: doc.result,
+  timeControl: doc.timeControl,
+  rated: doc.rated,
+  playedAt: doc.playedAt?.toISOString(),
+  pgn: doc.pgn,
+  movesSan: doc.movesSan,
+  orientation: doc.orientation,
+  tournamentGroup: doc.tournamentGroup,
+  tags: doc.tags,
+});
+
+const getMainLineSan = (moveNodes: unknown, maxPlies: number): string[] => {
+  const result: string[] = [];
+  let node = moveNodes as { children?: Array<{ move?: { san?: string }; children?: unknown[] }> };
+  while (node && Array.isArray(node.children) && node.children[0] && result.length < maxPlies) {
+    const first = node.children[0] as { move?: { san?: string }; children?: unknown[] };
+    if (!first.move?.san) {
+      break;
+    }
+    result.push(first.move.san);
+    node = first as unknown as { children?: Array<{ move?: { san?: string }; children?: unknown[] }> };
+  }
+  return result;
+};
+
+const nameSimilarity = (a: string, b: string): number => {
+  const al = a.toLowerCase();
+  const bl = b.toLowerCase();
+  if (!al || !bl) {
+    return 0;
+  }
+  if (al === bl) {
+    return 1;
+  }
+  if (al.includes(bl) || bl.includes(al)) {
+    return 0.82;
+  }
+  const aTokens = new Set(al.split(/\s+/));
+  const bTokens = new Set(bl.split(/\s+/));
+  let overlap = 0;
+  aTokens.forEach((token) => {
+    if (bTokens.has(token)) {
+      overlap += 1;
+    }
+  });
+  return overlap / Math.max(aTokens.size, bTokens.size, 1);
+};
+
+const toTimeControlBucket = (value?: string): "bullet" | "blitz" | "rapid" | "classical" | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const raw = value.split("+")[0];
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds)) {
+    return undefined;
+  }
+  if (seconds < 180) {
+    return "bullet";
+  }
+  if (seconds < 600) {
+    return "blitz";
+  }
+  if (seconds < 1800) {
+    return "rapid";
+  }
+  return "classical";
+};
+
+const parseDateHeader = (value?: string): Date | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = value.replace(/\./g, "-");
+  const date = new Date(normalized);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date;
+};
+
+async function buildOpeningMapping(userId: string, openingName: string | undefined, eco: string | undefined, lineMovesSan: string[], tags?: string[]): Promise<OpeningMapping> {
+  const db = getDB();
+  const repertoires = await db.collection("repertoires").find({ userId }).project({ _id: 1, name: 1, moveNodes: 1 }).toArray();
+  let best: OpeningMapping = { confidence: 0, strategy: "none", requiresManualReview: true };
+
+  repertoires.forEach((repertoire) => {
+    const repName = String(repertoire.name || "");
+    const repLine = getMainLineSan(repertoire.moveNodes, 12);
+    if (eco && repName.toLowerCase().includes(eco.toLowerCase())) {
+      const candidate: OpeningMapping = {
+        repertoireId: repertoire._id.toString(),
+        repertoireName: repName,
+        confidence: 0.92,
+        strategy: "eco",
+        requiresManualReview: false,
+      };
+      if (candidate.confidence > best.confidence) {
+        best = candidate;
+      }
+    }
+    if (repLine.length > 0 && lineMovesSan.length > 0) {
+      const overlap = repLine.filter((move, index) => lineMovesSan[index] === move).length;
+      const ratio = overlap / Math.max(Math.min(repLine.length, lineMovesSan.length), 1);
+      if (ratio > best.confidence) {
+        best = {
+          repertoireId: repertoire._id.toString(),
+          repertoireName: repName,
+          confidence: ratio,
+          strategy: "movePrefix",
+          requiresManualReview: ratio < 0.75,
+        };
+      }
+    }
+    const fuzzy = nameSimilarity(openingName || "", repName);
+    if (fuzzy > best.confidence) {
+      best = {
+        repertoireId: repertoire._id.toString(),
+        repertoireName: repName,
+        confidence: fuzzy,
+        strategy: "fuzzyName",
+        requiresManualReview: fuzzy < 0.75,
+      };
+    }
+    const tagScore = tags?.some((tag) => repName.toLowerCase().includes(tag.toLowerCase())) ? 0.76 : 0;
+    if (tagScore > best.confidence) {
+      best = {
+        repertoireId: repertoire._id.toString(),
+        repertoireName: repName,
+        confidence: tagScore,
+        strategy: "tagOverlap",
+        requiresManualReview: false,
+      };
+    }
+  });
+  if (best.confidence < 0.75) {
+    return { ...best, requiresManualReview: true };
+  }
+  return best;
+}
+
+export async function listLinkedAccounts(userId: string): Promise<LinkedGameAccount[]> {
+  const db = getDB();
+  const accounts = await db.collection<LinkedGameAccountDocument>("linkedGameAccounts").find({ userId }).toArray();
+  return accounts.map((doc) => mapAccount({ ...doc, _id: doc._id as unknown as ObjectId }));
+}
+
+export async function upsertLinkedAccount(userId: string, provider: "lichess" | "chesscom", username: string, token?: string): Promise<LinkedGameAccount> {
+  const db = getDB();
+  const now = new Date();
+  await db.collection<LinkedGameAccountDocument>("linkedGameAccounts").updateOne(
+    { userId, provider },
+    {
+      $set: {
+        userId,
+        provider,
+        username,
+        status: "idle",
+        connectedAt: now,
+        ...(token ? { tokenEncrypted: encryptSecret(token) } : {}),
+      },
+      $setOnInsert: { connectedAt: now },
+    },
+    { upsert: true }
+  );
+  const account = await db.collection<LinkedGameAccountDocument>("linkedGameAccounts").findOne({ userId, provider });
+  return mapAccount({ ...(account as LinkedGameAccountDocument), _id: account?._id as unknown as ObjectId });
+}
+
+export async function disconnectLinkedAccount(userId: string, provider: "lichess" | "chesscom"): Promise<void> {
+  const db = getDB();
+  await db.collection("linkedGameAccounts").deleteOne({ userId, provider });
+}
+
+export async function importGamesForUser(userId: string, input: ProviderImportInput): Promise<ImportSummary> {
+  const db = getDB();
+  const accountsCollection = db.collection<LinkedGameAccountDocument>("linkedGameAccounts");
+  const gamesCollection = db.collection<ImportedGameDocument>("importedGames");
+
+  let importedCount = 0;
+  let duplicateCount = 0;
+  let failedCount = 0;
+  const now = new Date();
+
+  const setAccountStatus = async (provider: "lichess" | "chesscom", status: "running" | "failed" | "completed", lastError?: string) => {
+    await accountsCollection.updateOne(
+      { userId, provider },
+      { $set: { status, lastError, ...(status === "completed" ? { lastSyncAt: now } : {}) } }
+    );
+  };
+
+  const linked = input.source === "manual" ? null : await accountsCollection.findOne({ userId, provider: input.source });
+  const username = input.username || linked?.username;
+  const token = input.token || decryptSecret(linked?.tokenEncrypted);
+
+  try {
+    if (input.source !== "manual") {
+      await setAccountStatus(input.source, "running");
+    }
+
+    const providerGames =
+      input.source === "manual"
+        ? (await manualPgnProvider.importGames(input.pgn || "")).map((game) => ({ ...game, providerGameId: undefined }))
+        : input.source === "lichess"
+          ? await lichessProvider.importGames({ username: username || "", token, since: linked?.lastSyncAt, max: 250 })
+          : await chessComProvider.importGames({ username: username || "", since: linked?.lastSyncAt, max: 250 });
+
+    for (const game of providerGames) {
+      try {
+        const white = game.headers.White || "Unknown";
+        const black = game.headers.Black || "Unknown";
+        const playedAt = parseDateHeader(game.headers.UTCDate || game.headers.Date);
+        const dedupeKey = game.providerGameId
+          ? `${input.source}:${game.providerGameId}`
+          : buildFallbackDedupeKey(playedAt?.toISOString(), white, black, game.headers.Result, game.movesSan);
+        const alreadyExists = await gamesCollection.findOne({ userId, dedupeKey }, { projection: { _id: 1 } });
+        if (alreadyExists) {
+          duplicateCount += 1;
+          continue;
+        }
+
+        const openingDetection = detectOpening(game.headers, game.movesSan);
+        const openingMapping = await buildOpeningMapping(userId, openingDetection.openingName, openingDetection.eco, openingDetection.lineMovesSan, input.tags);
+        const result = toNormalizedResult(game.headers.Result);
+        const doc: ImportedGameDocument = {
+          userId,
+          source: input.source,
+          providerGameId: game.providerGameId,
+          dedupeKey,
+          white,
+          black,
+          whiteRating: Number(game.headers.WhiteElo) || undefined,
+          blackRating: Number(game.headers.BlackElo) || undefined,
+          result,
+          timeControl: game.headers.TimeControl,
+          rated: game.headers.Rated ? game.headers.Rated.toLowerCase() === "true" : undefined,
+          playedAt,
+          pgn: game.pgn,
+          movesSan: game.movesSan,
+          orientation: inferOrientation(username, white, black),
+          tournamentGroup: input.tournamentGroup,
+          tags: input.tags,
+          openingDetection,
+          openingMapping,
+          createdAt: now,
+        };
+        await gamesCollection.insertOne(doc);
+        importedCount += 1;
+      } catch {
+        failedCount += 1;
+      }
+    }
+
+    if (input.source !== "manual") {
+      await setAccountStatus(input.source, "completed");
+    }
+  } catch (error) {
+    if (input.source !== "manual") {
+      await setAccountStatus(input.source, "failed", error instanceof Error ? error.message : "Import failed");
+    }
+    throw error;
+  }
+
+  return {
+    importedCount,
+    duplicateCount,
+    failedCount,
+    statsRefreshedAt: now.toISOString(),
+  };
+}
+
+export async function listImportedGames(userId: string, limit = 100): Promise<ImportedGame[]> {
+  const db = getDB();
+  const docs = await db.collection<ImportedGameDocument>("importedGames").find({ userId }).sort({ playedAt: -1, createdAt: -1 }).limit(limit).toArray();
+  return docs.map((doc) => mapImportedGame({ ...doc, _id: doc._id as unknown as ObjectId }));
+}
+
+const buildStatsFilter = (userId: string, filters: GameStatsFilters): Record<string, unknown> => {
+  const filter: Record<string, unknown> = { userId };
+  if (filters.dateFrom || filters.dateTo) {
+    filter.playedAt = {
+      ...(filters.dateFrom ? { $gte: new Date(filters.dateFrom) } : {}),
+      ...(filters.dateTo ? { $lte: new Date(filters.dateTo) } : {}),
+    };
+  }
+  if (filters.ratedOnly) {
+    filter.rated = true;
+  }
+  if (filters.color) {
+    filter.orientation = filters.color;
+  }
+  if (filters.tournamentGroup) {
+    filter.tournamentGroup = filters.tournamentGroup;
+  }
+  return filter;
+};
+
+const computeResults = (games: ImportedGameDocument[]) => {
+  let wins = 0;
+  let draws = 0;
+  let losses = 0;
+  games.forEach((game) => {
+    if (game.orientation === "white") {
+      if (game.result === "1-0") wins += 1;
+      else if (game.result === "0-1") losses += 1;
+      else if (game.result === "1/2-1/2") draws += 1;
+      return;
+    }
+    if (game.orientation === "black") {
+      if (game.result === "0-1") wins += 1;
+      else if (game.result === "1-0") losses += 1;
+      else if (game.result === "1/2-1/2") draws += 1;
+      return;
+    }
+    if (game.result === "1/2-1/2") {
+      draws += 1;
+    }
+  });
+  return { wins, draws, losses };
+};
+
+const topOpenings = (games: ImportedGameDocument[]): Array<{ openingName: string; count: number }> => {
+  const counts = new Map<string, number>();
+  games.forEach((game) => {
+    const openingName = game.openingDetection.openingName || "Unknown";
+    counts.set(openingName, (counts.get(openingName) || 0) + 1);
+  });
+  return [...counts.entries()].map(([openingName, count]) => ({ openingName, count })).sort((a, b) => b.count - a.count).slice(0, 10);
+};
+
+const buildLinesToStudy = (games: ImportedGameDocument[]): LineStudyCandidate[] => {
+  const grouped = new Map<string, ImportedGameDocument[]>();
+  games.forEach((game) => {
+    const key = game.openingDetection.lineKey;
+    grouped.set(key, [...(grouped.get(key) || []), game]);
+  });
+  const now = Date.now();
+  return [...grouped.entries()].map(([lineKey, lineGames]) => {
+    const { wins, draws, losses } = computeResults(lineGames);
+    const total = lineGames.length;
+    const winRate = total > 0 ? (wins + draws * 0.5) / total : 0;
+    const underperformanceScore = 1 - winRate;
+    const recentTs = Math.max(...lineGames.map((game) => game.playedAt?.getTime() || 0));
+    const recencyScore = recentTs ? Math.max(0, 1 - (now - recentTs) / (1000 * 60 * 60 * 24 * 60)) : 0;
+    const frequencyScore = Math.min(1, total / 10);
+    const deviationRate = lineGames.filter((game) => game.openingMapping.requiresManualReview).length / total;
+    return {
+      lineKey,
+      eco: lineGames[0].openingDetection.eco,
+      openingName: lineGames[0].openingDetection.openingName || "Unknown",
+      movesSan: lineGames[0].openingDetection.lineMovesSan,
+      sampleGameIds: lineGames.slice(0, 3).map((game) => String(game._id || "")),
+      games: total,
+      wins,
+      draws,
+      losses,
+      deviationRate,
+      underperformanceScore,
+      recencyScore,
+      frequencyScore,
+      suggestedTasks: [
+        "Review main line",
+        `Drill line to ply ${Math.min(12, lineGames[0].openingDetection.lineMovesSan.length)}`,
+        "Practice with constrained sparring game",
+      ],
+    };
+  }).filter((line) => line.underperformanceScore > 0.35 || line.frequencyScore > 0.35 || line.recencyScore > 0.5 || line.deviationRate > 0.3)
+    .sort((a, b) => (b.underperformanceScore + b.frequencyScore + b.recencyScore + b.deviationRate) - (a.underperformanceScore + a.frequencyScore + a.recencyScore + a.deviationRate))
+    .slice(0, 12);
+};
+
+export async function getGamesStats(userId: string, filters: GameStatsFilters): Promise<GamesStatsSummary> {
+  const db = getDB();
+  const collection = db.collection<ImportedGameDocument>("importedGames");
+  const allGames = await collection.find(buildStatsFilter(userId, filters)).toArray();
+  const bucketed = filters.timeControlBucket ? allGames.filter((game) => toTimeControlBucket(game.timeControl) === filters.timeControlBucket) : allGames;
+  const { wins, draws, losses } = computeResults(bucketed);
+  const totalGames = bucketed.length;
+  return {
+    totalGames,
+    wins,
+    draws,
+    losses,
+    winRate: totalGames > 0 ? (wins + draws * 0.5) / totalGames : 0,
+    topOpenings: topOpenings(bucketed),
+    linesToStudy: buildLinesToStudy(bucketed),
+  };
+}
+
+const buildPriority = (line: LineStudyCandidate, weights: TrainingPlanWeights, repertoireGap: number): number => {
+  const problem = Math.min(1, line.underperformanceScore + line.deviationRate * 0.5);
+  return (
+    weights.frequency * line.frequencyScore +
+    weights.problem * problem +
+    weights.recency * line.recencyScore +
+    weights.repertoireGap * repertoireGap +
+    weights.deviationRate * line.deviationRate
+  );
+};
+
+export async function generateTrainingPlan(userId: string, weights?: Partial<TrainingPlanWeights>): Promise<TrainingPlan> {
+  const mergedWeights: TrainingPlanWeights = { ...DEFAULT_TRAINING_PLAN_WEIGHTS, ...weights };
+  const stats = await getGamesStats(userId, {});
+  const db = getDB();
+  const items = stats.linesToStudy.map((line) => {
+    const repertoireGap = line.deviationRate;
+    const priority = buildPriority(line, mergedWeights, repertoireGap);
+    return {
+      lineKey: line.lineKey,
+      openingName: line.openingName,
+      movesSan: line.movesSan,
+      priority,
+      reasons: [
+        line.underperformanceScore > 0.4 ? "Underperforming line" : "",
+        line.frequencyScore > 0.4 ? "High frequency in your games" : "",
+        line.recencyScore > 0.5 ? "Recently played" : "",
+        line.deviationRate > 0.3 ? "Early deviations from repertoire" : "",
+      ].filter(Boolean),
+      effort: (priority > 0.7 ? "high" : priority > 0.4 ? "medium" : "low") as "high" | "medium" | "low",
+      tasks: line.suggestedTasks,
+      done: false,
+    };
+  }).sort((a, b) => b.priority - a.priority);
+
+  const plan: TrainingPlan = {
+    id: new ObjectId().toString(),
+    generatedAt: new Date().toISOString(),
+    weights: mergedWeights,
+    items,
+  };
+
+  const doc: TrainingPlanDocument = {
+    ...plan,
+    userId,
+    generatedAtDate: new Date(plan.generatedAt),
+  };
+  await db.collection<TrainingPlanDocument>("trainingPlans").insertOne(doc);
+  return plan;
+}
+
+export async function getLatestTrainingPlan(userId: string): Promise<TrainingPlan | null> {
+  const db = getDB();
+  const plan = await db.collection<TrainingPlanDocument>("trainingPlans").findOne({ userId }, { sort: { generatedAtDate: -1 } });
+  if (!plan) {
+    return null;
+  }
+  return {
+    id: plan.id,
+    generatedAt: plan.generatedAt,
+    weights: plan.weights,
+    items: plan.items,
+  };
+}
+
+export async function markTrainingPlanItemDone(userId: string, planId: string, lineKey: string, done: boolean): Promise<void> {
+  const db = getDB();
+  await db.collection<TrainingPlanDocument>("trainingPlans").updateOne(
+    { userId, id: planId, "items.lineKey": lineKey },
+    { $set: { "items.$.done": done } }
+  );
+}

--- a/packages/backend/src/services/games/pgnProcessing.ts
+++ b/packages/backend/src/services/games/pgnProcessing.ts
@@ -1,0 +1,130 @@
+import { createHash } from "crypto";
+import { OpeningDetection } from "@chess-opening-master/common";
+
+export interface ParsedPgnGame {
+  headers: Record<string, string>;
+  pgn: string;
+  movesSan: string[];
+}
+
+const HEADER_RE = /^\s*\[(\w+)\s+"(.*)"\]\s*$/;
+
+const parseHeaders = (block: string): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  const lines = block.split(/\r?\n/);
+  lines.forEach((line) => {
+    const match = line.match(HEADER_RE);
+    if (match) {
+      headers[match[1]] = match[2];
+    }
+  });
+  return headers;
+};
+
+const sanitizePgnBody = (value: string): string => value
+  .replace(/\{[^}]*\}/g, " ")
+  .replace(/\([^)]*\)/g, " ")
+  .replace(/\$\d+/g, " ")
+  .replace(/\r/g, " ")
+  .replace(/\n/g, " ");
+
+const extractMoves = (body: string): string[] => {
+  const tokens = sanitizePgnBody(body).split(/\s+/).filter(Boolean);
+  const moves: string[] = [];
+  tokens.forEach((token) => {
+    if (/^\d+\.+$/.test(token) || /^\d+\.{3}$/.test(token)) {
+      return;
+    }
+    if (/^\d+\./.test(token)) {
+      const cleaned = token.replace(/^\d+\.{1,3}/, "");
+      if (cleaned) {
+        moves.push(cleaned);
+      }
+      return;
+    }
+    if (token === "1-0" || token === "0-1" || token === "1/2-1/2" || token === "*") {
+      return;
+    }
+    moves.push(token);
+  });
+  return moves;
+};
+
+export const splitPgnGames = (rawPgn: string): string[] => {
+  const normalized = rawPgn.replace(/\r/g, "").trim();
+  if (!normalized) {
+    return [];
+  }
+  const chunks = normalized.split(/\n(?=\[Event\s+")/g);
+  return chunks.map((chunk) => chunk.trim()).filter(Boolean);
+};
+
+export const parsePgnGames = (rawPgn: string): ParsedPgnGame[] => {
+  return splitPgnGames(rawPgn).flatMap((chunk) => {
+    const [headerSection, ...rest] = chunk.split(/\n\n/);
+    const moveSection = rest.join("\n\n");
+    const movesSan = extractMoves(moveSection);
+    if (!headerSection || movesSan.length === 0) {
+      return [];
+    }
+    return [{ headers: parseHeaders(headerSection), pgn: chunk, movesSan }];
+  });
+};
+
+const normalizeResult = (value?: string): "1-0" | "0-1" | "1/2-1/2" | "*" => {
+  if (value === "1-0" || value === "0-1" || value === "1/2-1/2") {
+    return value;
+  }
+  return "*";
+};
+
+export const inferOrientation = (username: string | undefined, white: string, black: string): "white" | "black" | undefined => {
+  if (!username) {
+    return undefined;
+  }
+  const normalized = username.toLowerCase();
+  if (white.toLowerCase() === normalized) {
+    return "white";
+  }
+  if (black.toLowerCase() === normalized) {
+    return "black";
+  }
+  return undefined;
+};
+
+export const detectOpening = (headers: Record<string, string>, movesSan: string[], maxPlies = 12): OpeningDetection => {
+  const lineMovesSan = movesSan.slice(0, maxPlies);
+  const fallbackSignature = lineMovesSan.join(" ").toLowerCase();
+  const lineKey = createHash("sha256").update(fallbackSignature).digest("hex").slice(0, 16);
+  const eco = headers.ECO?.trim();
+  const openingName = headers.Opening?.trim() || headers.Variation?.trim();
+  if (eco || openingName) {
+    return {
+      eco,
+      openingName,
+      lineMovesSan,
+      lineKey,
+      confidence: eco && openingName ? 0.95 : 0.8,
+      fallbackSignature,
+    };
+  }
+  return {
+    lineMovesSan,
+    lineKey,
+    confidence: lineMovesSan.length >= 6 ? 0.6 : 0.45,
+    fallbackSignature,
+  };
+};
+
+export const buildFallbackDedupeKey = (
+  playedAt: string | undefined,
+  white: string,
+  black: string,
+  result: string,
+  movesSan: string[]
+): string => {
+  const value = `${playedAt || "unknown"}|${white.toLowerCase()}|${black.toLowerCase()}|${normalizeResult(result)}|${movesSan.join(" ")}`;
+  return createHash("sha256").update(value).digest("hex");
+};
+
+export const toNormalizedResult = normalizeResult;

--- a/packages/backend/src/services/games/providers/chessComProvider.ts
+++ b/packages/backend/src/services/games/providers/chessComProvider.ts
@@ -1,0 +1,62 @@
+import { parsePgnGames } from "../pgnProcessing";
+
+export interface ChessComImportOptions {
+  username: string;
+  since?: Date;
+  max?: number;
+}
+
+interface ChessComArchiveGame {
+  uuid?: string;
+  pgn?: string;
+  end_time?: number;
+}
+
+const monthFromArchive = (url: string): Date | null => {
+  const match = url.match(/\/(\d{4})\/(\d{2})$/);
+  if (!match) {
+    return null;
+  }
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+};
+
+export const chessComProvider = {
+  async importGames(options: ChessComImportOptions) {
+    const archiveResponse = await fetch(`https://api.chess.com/pub/player/${encodeURIComponent(options.username)}/games/archives`);
+    if (!archiveResponse.ok) {
+      throw new Error(`Chess.com archive fetch failed: ${archiveResponse.status}`);
+    }
+    const archivesPayload = (await archiveResponse.json()) as { archives?: string[] };
+    const archives = (archivesPayload.archives || []).filter((url) => {
+      if (!options.since) {
+        return true;
+      }
+      const month = monthFromArchive(url);
+      return month ? month.getTime() >= options.since.getTime() - 31 * 24 * 60 * 60 * 1000 : true;
+    });
+    const ordered = archives.slice(-12).reverse();
+    const games: Array<{ providerGameId?: string; pgn: string }> = [];
+    for (const archiveUrl of ordered) {
+      if (options.max && games.length >= options.max) {
+        break;
+      }
+      const response = await fetch(archiveUrl);
+      if (!response.ok) {
+        continue;
+      }
+      const payload = (await response.json()) as { games?: ChessComArchiveGame[] };
+      (payload.games || []).forEach((game) => {
+        if (!game.pgn) {
+          return;
+        }
+        if (options.since && game.end_time && game.end_time * 1000 < options.since.getTime()) {
+          return;
+        }
+        if (!options.max || games.length < options.max) {
+          games.push({ providerGameId: game.uuid, pgn: game.pgn });
+        }
+      });
+    }
+    return games.flatMap((entry) => parsePgnGames(entry.pgn).map((parsed) => ({ ...parsed, providerGameId: entry.providerGameId })));
+  },
+};

--- a/packages/backend/src/services/games/providers/lichessProvider.ts
+++ b/packages/backend/src/services/games/providers/lichessProvider.ts
@@ -1,0 +1,33 @@
+import { parsePgnGames } from "../pgnProcessing";
+
+export interface LichessImportOptions {
+  username: string;
+  token?: string;
+  since?: Date;
+  max?: number;
+}
+
+const splitNdjson = (raw: string): string[] => raw.split("\n").map((line) => line.trim()).filter(Boolean);
+
+export const lichessProvider = {
+  async importGames(options: LichessImportOptions) {
+    const params = new URLSearchParams();
+    params.set("pgnInJson", "true");
+    params.set("max", String(options.max || 100));
+    if (options.since) {
+      params.set("since", String(options.since.getTime()));
+    }
+    const response = await fetch(`https://lichess.org/api/games/user/${encodeURIComponent(options.username)}?${params.toString()}`, {
+      headers: {
+        Accept: "application/x-ndjson",
+        ...(options.token ? { Authorization: `Bearer ${options.token}` } : {}),
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Lichess import failed: ${response.status}`);
+    }
+    const raw = await response.text();
+    const games = splitNdjson(raw).map((line) => JSON.parse(line) as { id?: string; pgn?: string }).filter((entry) => Boolean(entry.pgn));
+    return games.flatMap((entry) => parsePgnGames(entry.pgn || "").map((parsed) => ({ ...parsed, providerGameId: entry.id })));
+  },
+};

--- a/packages/backend/src/services/games/providers/manualPgnProvider.ts
+++ b/packages/backend/src/services/games/providers/manualPgnProvider.ts
@@ -1,0 +1,7 @@
+import { parsePgnGames } from "../pgnProcessing";
+
+export const manualPgnProvider = {
+  async importGames(rawPgn: string) {
+    return parsePgnGames(rawPgn);
+  },
+};

--- a/packages/backend/src/services/games/security.ts
+++ b/packages/backend/src/services/games/security.ts
@@ -1,0 +1,30 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "crypto";
+
+const ENCRYPTION_SECRET = process.env.GAME_PROVIDER_TOKEN_SECRET || "development-game-provider-secret";
+
+const buildKey = (): Buffer => createHash("sha256").update(ENCRYPTION_SECRET).digest();
+
+export const encryptSecret = (value: string): string => {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", buildKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `${iv.toString("hex")}:${authTag.toString("hex")}:${encrypted.toString("hex")}`;
+};
+
+export const decryptSecret = (value?: string): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const [ivHex, tagHex, encryptedHex] = value.split(":");
+  if (!ivHex || !tagHex || !encryptedHex) {
+    return undefined;
+  }
+  const decipher = createDecipheriv("aes-256-gcm", buildKey(), Buffer.from(ivHex, "hex"));
+  decipher.setAuthTag(Buffer.from(tagHex, "hex"));
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(encryptedHex, "hex")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+};

--- a/packages/backend/src/services/test/pgnProcessing.spec.ts
+++ b/packages/backend/src/services/test/pgnProcessing.spec.ts
@@ -1,0 +1,27 @@
+import { buildFallbackDedupeKey, detectOpening, parsePgnGames, splitPgnGames } from "../games/pgnProcessing";
+
+describe("pgnProcessing", () => {
+  it("parses multi-game PGN payload", () => {
+    const raw = `[Event "Game 1"]\n[White "Alice"]\n[Black "Bob"]\n[Result "1-0"]\n\n1. e4 e5 2. Nf3 Nc6 1-0\n\n[Event "Game 2"]\n[White "Carol"]\n[Black "Dave"]\n[Result "0-1"]\n\n1. d4 d5 2. c4 e6 0-1`;
+    const chunks = splitPgnGames(raw);
+    expect(chunks).toHaveLength(2);
+    const parsed = parsePgnGames(raw);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0].headers.White).toBe("Alice");
+    expect(parsed[1].movesSan.slice(0, 2)).toEqual(["d4", "d5"]);
+  });
+
+  it("uses eco and opening headers for opening detection", () => {
+    const opening = detectOpening({ ECO: "C20", Opening: "King Pawn Game" }, ["e4", "e5", "Nf3", "Nc6"]);
+    expect(opening.eco).toBe("C20");
+    expect(opening.openingName).toBe("King Pawn Game");
+    expect(opening.confidence).toBeGreaterThan(0.9);
+    expect(opening.lineKey).toHaveLength(16);
+  });
+
+  it("produces stable fallback dedupe key", () => {
+    const keyA = buildFallbackDedupeKey("2024-01-01T00:00:00.000Z", "Alice", "Bob", "1-0", ["e4", "e5"]);
+    const keyB = buildFallbackDedupeKey("2024-01-01T00:00:00.000Z", "Alice", "Bob", "1-0", ["e4", "e5"]);
+    expect(keyA).toBe(keyB);
+  });
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -34,3 +34,20 @@ export {
   validatePasswordStrength,
   PasswordValidationResult,
 } from "./utils/passwordPolicy";
+
+export {
+  GameSource,
+  LinkedAccountProvider,
+  SyncStatus,
+  LinkedGameAccount,
+  ImportedGame,
+  OpeningDetection,
+  OpeningMapping,
+  ImportSummary,
+  GameStatsFilters,
+  LineStudyCandidate,
+  GamesStatsSummary,
+  TrainingPlanWeights,
+  TrainingPlanItem,
+  TrainingPlan,
+} from "./types/GameImports";

--- a/packages/common/src/types/GameImports.ts
+++ b/packages/common/src/types/GameImports.ts
@@ -1,0 +1,123 @@
+import { BoardOrientation } from "./Orientation";
+
+export type GameSource = "lichess" | "chesscom" | "manual";
+
+export type LinkedAccountProvider = "lichess" | "chesscom";
+
+export type SyncStatus = "idle" | "running" | "failed" | "completed";
+
+export interface LinkedGameAccount {
+  id: string;
+  provider: LinkedAccountProvider;
+  username: string;
+  connectedAt: string;
+  lastSyncAt?: string;
+  status: SyncStatus;
+  lastError?: string;
+}
+
+export interface ImportedGame {
+  id: string;
+  source: GameSource;
+  providerGameId?: string;
+  white: string;
+  black: string;
+  whiteRating?: number;
+  blackRating?: number;
+  result: "1-0" | "0-1" | "1/2-1/2" | "*";
+  timeControl?: string;
+  rated?: boolean;
+  playedAt?: string;
+  pgn: string;
+  movesSan: string[];
+  orientation?: BoardOrientation;
+  tournamentGroup?: string;
+  tags?: string[];
+}
+
+export interface OpeningDetection {
+  eco?: string;
+  openingName?: string;
+  lineMovesSan: string[];
+  lineKey: string;
+  confidence: number;
+  fallbackSignature?: string;
+}
+
+export interface OpeningMapping {
+  repertoireId?: string;
+  repertoireName?: string;
+  confidence: number;
+  strategy: "eco" | "movePrefix" | "fuzzyName" | "tagOverlap" | "manual" | "none";
+  requiresManualReview: boolean;
+}
+
+export interface ImportSummary {
+  importedCount: number;
+  duplicateCount: number;
+  failedCount: number;
+  statsRefreshedAt: string;
+}
+
+export interface GameStatsFilters {
+  dateFrom?: string;
+  dateTo?: string;
+  timeControlBucket?: "bullet" | "blitz" | "rapid" | "classical";
+  ratedOnly?: boolean;
+  color?: BoardOrientation;
+  opponentRatingBand?: string;
+  tournamentGroup?: string;
+}
+
+export interface LineStudyCandidate {
+  lineKey: string;
+  eco?: string;
+  openingName: string;
+  movesSan: string[];
+  sampleGameIds: string[];
+  games: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  deviationRate: number;
+  underperformanceScore: number;
+  recencyScore: number;
+  frequencyScore: number;
+  suggestedTasks: string[];
+}
+
+export interface GamesStatsSummary {
+  totalGames: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  winRate: number;
+  topOpenings: Array<{ openingName: string; count: number }>;
+  linesToStudy: LineStudyCandidate[];
+}
+
+export interface TrainingPlanWeights {
+  frequency: number;
+  problem: number;
+  recency: number;
+  repertoireGap: number;
+  deviationRate: number;
+}
+
+export interface TrainingPlanItem {
+  lineKey: string;
+  openingName: string;
+  movesSan: string[];
+  priority: number;
+  reasons: string[];
+  effort: "low" | "medium" | "high";
+  tasks: string[];
+  done: boolean;
+}
+
+export interface TrainingPlan {
+  id: string;
+  generatedAt: string;
+  weights: TrainingPlanWeights;
+  items: TrainingPlanItem[];
+}

--- a/packages/frontend/src/components/application/Content/Content.tsx
+++ b/packages/frontend/src/components/application/Content/Content.tsx
@@ -9,6 +9,7 @@ import PathPage from "../../../pages/PathPage/PathPage";
 import StudiesPage from "../../../pages/StudiesPage/StudiesPage";
 import LoginPage from "../../../pages/auth/LoginPage";
 import RegisterPage from "../../../pages/auth/RegisterPage";
+import GamesPage from "../../../pages/games/GamesPage";
 
 interface ContentProps {
   authEnabled: boolean;
@@ -41,6 +42,7 @@ const Content: React.FC<ContentProps> = ({ authEnabled, authenticated, allowDefa
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/studies" element={<StudiesPage />} />
         <Route path="/path" element={<PathPage />} />
+        <Route path="/games" element={<GamesPage />} />
         <Route path="/" element={<Navigate to="/dashboard" />} />
       </Routes>
     </MainContainer>

--- a/packages/frontend/src/components/application/NavbarContainer/NavbarContainer.tsx
+++ b/packages/frontend/src/components/application/NavbarContainer/NavbarContainer.tsx
@@ -104,6 +104,7 @@ const NavbarContainer: React.FC<NavbarContainerProps> = ({ authEnabled, onLogged
       ? [{id: "download_repertoires", name: "Download Repertoires", url: "#", onClick: handleDownloadRepertoires, icon: <ArrowDownTrayIcon className="h-6 w-6 mr-2" />}]
       : []),
     { id: "create_repertoire", name: "Create Repertoire", url: "/create-repertoire", icon: <PlusIcon className="h-6 w-6 mr-2" /> },
+    { id: "my_games", name: "My Games", url: "/games", icon: <ArrowDownTrayIcon className="h-6 w-6 mr-2" /> },
   ]}
   showLogout={authEnabled}
   onLogout={handleLogout}

--- a/packages/frontend/src/pages/games/GamesPage.tsx
+++ b/packages/frontend/src/pages/games/GamesPage.tsx
@@ -1,0 +1,208 @@
+import React from "react";
+import {
+  generateTrainingPlan,
+  getGamesStats,
+  getImportedGames,
+  getLinkedAccounts,
+  getTrainingPlan,
+  importGames,
+  removeLinkedAccount,
+  saveLinkedAccount,
+  setTrainingPlanItemDone,
+} from "../../repository/games/games";
+import { LinkedGameAccount, TrainingPlan } from "@chess-opening-master/common";
+
+const providerOptions: Array<{ value: "lichess" | "chesscom"; label: string }> = [
+  { value: "lichess", label: "Lichess" },
+  { value: "chesscom", label: "Chess.com" },
+];
+
+const GamesPage: React.FC = () => {
+  const [accounts, setAccounts] = React.useState<LinkedGameAccount[]>([]);
+  const [gamesCount, setGamesCount] = React.useState(0);
+  const [statsSummary, setStatsSummary] = React.useState<string>("");
+  const [trainingPlan, setTrainingPlan] = React.useState<TrainingPlan | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [message, setMessage] = React.useState<string>("");
+  const [provider, setProvider] = React.useState<"lichess" | "chesscom">("lichess");
+  const [username, setUsername] = React.useState("");
+  const [token, setToken] = React.useState("");
+  const [manualPgn, setManualPgn] = React.useState("");
+  const [tags, setTags] = React.useState("");
+  const [tournamentGroup, setTournamentGroup] = React.useState("");
+
+  const loadData = React.useCallback(async () => {
+    setLoading(true);
+    try {
+      const [nextAccounts, nextGames, nextStats, nextPlan] = await Promise.all([
+        getLinkedAccounts(),
+        getImportedGames(),
+        getGamesStats(),
+        getTrainingPlan(),
+      ]);
+      setAccounts(nextAccounts);
+      setGamesCount(nextGames.length);
+      setStatsSummary(`W:${nextStats.wins} D:${nextStats.draws} L:${nextStats.losses} · WinRate ${(nextStats.winRate * 100).toFixed(1)}%`);
+      setTrainingPlan(nextPlan);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Failed to load game insights");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    let ignore = false;
+    (async () => {
+      await loadData();
+      if (ignore) {
+        return;
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, [loadData]);
+
+  const connectAccount = async () => {
+    setMessage("");
+    try {
+      await saveLinkedAccount(provider, username, token || undefined);
+      await loadData();
+      setUsername("");
+      setToken("");
+      setMessage("Account linked");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Failed to link account");
+    }
+  };
+
+  const syncProvider = async (source: "lichess" | "chesscom") => {
+    setMessage("");
+    try {
+      const summary = await importGames({ source });
+      await loadData();
+      setMessage(`Sync complete. Imported ${summary.importedCount}, duplicates ${summary.duplicateCount}.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Sync failed");
+    }
+  };
+
+  const runManualImport = async () => {
+    setMessage("");
+    try {
+      const summary = await importGames({
+        source: "manual",
+        pgn: manualPgn,
+        tags: tags.split(",").map((tag) => tag.trim()).filter(Boolean),
+        tournamentGroup: tournamentGroup || undefined,
+      });
+      await loadData();
+      setMessage(`Manual import complete. Imported ${summary.importedCount}, duplicates ${summary.duplicateCount}.`);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Manual import failed");
+    }
+  };
+
+  const uploadPgnFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const text = await file.text();
+    setManualPgn(text);
+  };
+
+  const regeneratePlan = async () => {
+    try {
+      const plan = await generateTrainingPlan();
+      setTrainingPlan(plan);
+      setMessage("Training plan generated");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Failed to generate training plan");
+    }
+  };
+
+  const markDone = async (planId: string, lineKey: string, done: boolean) => {
+    await setTrainingPlanItemDone(planId, lineKey, done);
+    await loadData();
+  };
+
+  return (
+    <div className="p-4 sm:p-6 text-gray-100 space-y-6 overflow-auto h-full">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">My Games Insights</h1>
+        <button className="px-3 py-2 bg-blue-600 rounded" onClick={regeneratePlan}>Regenerate Training Plan</button>
+      </div>
+      {loading ? <p>Loading...</p> : null}
+      {message ? <div className="bg-slate-800 border border-slate-600 rounded p-3 text-sm">{message}</div> : null}
+
+      <section className="bg-slate-900 rounded border border-slate-700 p-4 space-y-3">
+        <h2 className="text-xl font-semibold">Linked Accounts</h2>
+        <div className="grid sm:grid-cols-4 gap-2">
+          <select value={provider} onChange={(event) => setProvider(event.target.value as "lichess" | "chesscom")} className="bg-slate-800 p-2 rounded">
+            {providerOptions.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+          <input value={username} onChange={(event) => setUsername(event.target.value)} className="bg-slate-800 p-2 rounded" placeholder="Username" />
+          <input value={token} onChange={(event) => setToken(event.target.value)} className="bg-slate-800 p-2 rounded" placeholder="Optional token" />
+          <button className="bg-emerald-600 rounded p-2" onClick={connectAccount}>Connect</button>
+        </div>
+        <div className="space-y-2">
+          {accounts.map((account) => (
+            <div key={account.id} className="flex flex-wrap gap-2 items-center bg-slate-800 rounded p-2">
+              <span className="font-medium">{account.provider} · {account.username}</span>
+              <span className="text-xs text-gray-300">Status: {account.status}</span>
+              <button className="bg-blue-600 rounded px-2 py-1 text-sm" onClick={() => syncProvider(account.provider)}>Sync</button>
+              <button className="bg-red-700 rounded px-2 py-1 text-sm" onClick={async () => { await removeLinkedAccount(account.provider); await loadData(); }}>Disconnect</button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="bg-slate-900 rounded border border-slate-700 p-4 space-y-3">
+        <h2 className="text-xl font-semibold">Manual PGN Import</h2>
+        <div className="grid sm:grid-cols-2 gap-2">
+          <input value={tournamentGroup} onChange={(event) => setTournamentGroup(event.target.value)} className="bg-slate-800 p-2 rounded" placeholder="Tournament or training group (optional)" />
+          <input value={tags} onChange={(event) => setTags(event.target.value)} className="bg-slate-800 p-2 rounded" placeholder="Tags (comma-separated)" />
+        </div>
+        <textarea value={manualPgn} onChange={(event) => setManualPgn(event.target.value)} className="w-full min-h-[180px] bg-slate-800 p-2 rounded" placeholder="Paste single or multi-game PGN" />
+        <div className="flex flex-wrap gap-2">
+          <input type="file" accept=".pgn" onChange={uploadPgnFile} className="text-sm" />
+          <button className="bg-indigo-600 rounded px-3 py-2" onClick={runManualImport}>Import PGN</button>
+        </div>
+      </section>
+
+      <section className="bg-slate-900 rounded border border-slate-700 p-4 space-y-2">
+        <h2 className="text-xl font-semibold">Statistics</h2>
+        <p>Total imported games: {gamesCount}</p>
+        <p>{statsSummary}</p>
+      </section>
+
+      <section className="bg-slate-900 rounded border border-slate-700 p-4 space-y-3">
+        <h2 className="text-xl font-semibold">Training Plan</h2>
+        {!trainingPlan ? <p>No training plan yet.</p> : (
+          <div className="space-y-2">
+            {trainingPlan.items.map((item, index) => (
+              <div key={item.lineKey} className="bg-slate-800 rounded p-3">
+                <div className="flex justify-between gap-2">
+                  <p className="font-medium">#{index + 1} {item.openingName}</p>
+                  <label className="text-sm flex items-center gap-1">
+                    <input type="checkbox" checked={item.done} onChange={(event) => { void markDone(trainingPlan.id, item.lineKey, event.target.checked); }} />
+                    Done
+                  </label>
+                </div>
+                <p className="text-xs text-gray-300">Priority {item.priority.toFixed(2)} · {item.effort}</p>
+                <p className="text-sm">{item.movesSan.join(" ")}</p>
+                <ul className="list-disc list-inside text-sm text-gray-300">
+                  {item.tasks.map((task) => <li key={task}>{task}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default GamesPage;

--- a/packages/frontend/src/repository/games/games.ts
+++ b/packages/frontend/src/repository/games/games.ts
@@ -1,0 +1,102 @@
+import { GamesStatsSummary, ImportedGame, ImportSummary, LinkedGameAccount, TrainingPlan, TrainingPlanWeights } from "@chess-opening-master/common";
+import { API_URL } from "../constants";
+import { apiFetch } from "../apiClient";
+
+const parseJson = async <T>(response: Response): Promise<T> => {
+  const payload = await response.json();
+  return payload as T;
+};
+
+const ensureOk = async (response: Response, fallback: string): Promise<void> => {
+  if (response.ok) {
+    return;
+  }
+  let message = fallback;
+  try {
+    const body = await response.json() as { message?: string };
+    if (body.message) {
+      message = body.message;
+    }
+  } catch {
+    message = fallback;
+  }
+  throw new Error(message);
+};
+
+export const getLinkedAccounts = async (): Promise<LinkedGameAccount[]> => {
+  const response = await apiFetch(`${API_URL}/games/accounts`);
+  await ensureOk(response, "Failed to load linked accounts");
+  return parseJson<LinkedGameAccount[]>(response);
+};
+
+export const saveLinkedAccount = async (provider: "lichess" | "chesscom", username: string, token?: string): Promise<LinkedGameAccount> => {
+  const response = await apiFetch(`${API_URL}/games/accounts`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, username, token }),
+  });
+  await ensureOk(response, "Failed to save linked account");
+  return parseJson<LinkedGameAccount>(response);
+};
+
+export const removeLinkedAccount = async (provider: "lichess" | "chesscom"): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/games/accounts/${provider}`, { method: "DELETE" });
+  await ensureOk(response, "Failed to disconnect account");
+};
+
+export const importGames = async (payload: {
+  source: "lichess" | "chesscom" | "manual";
+  username?: string;
+  token?: string;
+  pgn?: string;
+  tournamentGroup?: string;
+  tags?: string[];
+}): Promise<ImportSummary> => {
+  const response = await apiFetch(`${API_URL}/games/imports`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  await ensureOk(response, "Failed to import games");
+  return parseJson<ImportSummary>(response);
+};
+
+export const getImportedGames = async (): Promise<ImportedGame[]> => {
+  const response = await apiFetch(`${API_URL}/games/imports?limit=200`);
+  await ensureOk(response, "Failed to load imported games");
+  return parseJson<ImportedGame[]>(response);
+};
+
+export const getGamesStats = async (): Promise<GamesStatsSummary> => {
+  const response = await apiFetch(`${API_URL}/games/stats`);
+  await ensureOk(response, "Failed to load game stats");
+  return parseJson<GamesStatsSummary>(response);
+};
+
+export const generateTrainingPlan = async (weights?: Partial<TrainingPlanWeights>): Promise<TrainingPlan> => {
+  const response = await apiFetch(`${API_URL}/games/training-plan`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ weights }),
+  });
+  await ensureOk(response, "Failed to generate training plan");
+  return parseJson<TrainingPlan>(response);
+};
+
+export const getTrainingPlan = async (): Promise<TrainingPlan | null> => {
+  const response = await apiFetch(`${API_URL}/games/training-plan`);
+  if (response.status === 404) {
+    return null;
+  }
+  await ensureOk(response, "Failed to load training plan");
+  return parseJson<TrainingPlan>(response);
+};
+
+export const setTrainingPlanItemDone = async (planId: string, lineKey: string, done: boolean): Promise<void> => {
+  const response = await apiFetch(`${API_URL}/games/training-plan/${planId}/items/${lineKey}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ done }),
+  });
+  await ensureOk(response, "Failed to update plan item");
+};

--- a/src/doc/Game-Imports-Guide.md
+++ b/src/doc/Game-Imports-Guide.md
@@ -1,0 +1,41 @@
+# Game Imports and Training Plan Guide
+
+## Overview
+The application now includes a unified game ingestion flow for Lichess, Chess.com, and manual PGN imports.
+
+## Where to find it
+- Open **My Games** from the sidebar.
+- Route: `/games`.
+
+## Linked Accounts
+- Choose provider (`lichess` or `chesscom`).
+- Enter username and optional token.
+- Click **Connect**.
+- Use **Sync** to import new games since last sync.
+- Use **Disconnect** to remove provider link.
+
+## Manual PGN Import
+- Paste PGN directly into the textarea.
+- Or upload a `.pgn` file to preload the textarea.
+- Optional fields:
+  - Tournament/Training group
+  - Tags (comma-separated)
+- Click **Import PGN**.
+
+## Opening Classification and Mapping
+- Import pipeline reads ECO/Openings tags when available.
+- Otherwise it builds a line signature from the first 12 plies.
+- Detected lines are mapped to Saved Openings repertoires using confidence-based heuristics.
+
+## Statistics and Lines to Study
+- The My Games page shows total game count and W/D/L summary.
+- Lines to study are calculated from underperformance, frequency, recency, and deviation indicators.
+
+## Training Plan
+- Click **Regenerate Training Plan** to build a prioritized queue.
+- Mark items as done directly in the list.
+- Priorities use configurable weighted scoring under the hood.
+
+## Security
+- Linked provider tokens are encrypted at rest.
+- Requests remain cookie-authenticated and user-scoped.

--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -60,6 +60,12 @@ This directory contains comprehensive documentation for the Chess Opening Master
 - Path planning/analytics API and UI design
 - Phased rollout and acceptance criteria
 
+### ♟️ [Game Imports and Training Plan Guide](Game-Imports-Guide.md)
+**How to link providers, import PGN games, and use My Games insights/training plan**
+- Linked account setup and sync
+- Manual PGN paste/upload flow
+- Opening mapping and training plan usage
+
 ### 🔧 [Troubleshooting Guide](Troubleshooting-Guide.md)
 **First stop when encountering issues**
 - Common TypeScript compilation errors


### PR DESCRIPTION
### Motivation
- Provide a unified ingestion pipeline so users can import games from Lichess, Chess.com or via manual PGN and get opening detection, repertoire mapping, and prioritized training suggestions.
- Surface those capabilities via a simple UI and a scoped backend API so imports, stats and training plans are available to the frontend and can be persisted per user.
- Keep shared contracts consistent by exporting types in the `common` package so frontend/backend agree on import/training data shapes.

### Description
- Added shared types and exports for the game-import and training-plan contract in `@chess-opening-master/common` (`packages/common/src/types/GameImports.ts`, updated `packages/common/src/index.ts`).
- Implemented backend domain for game imports including PGN parsing, deduplication, opening detection (`lineKey`), mapping heuristics, provider adapters (`lichess`, `chess.com`, `manual`), token encryption, models, indexes and APIs mounted under `/games` (`packages/backend/src/services/games/*`, `models/GameImport.ts`, `controllers/gamesController.ts`, `routes/games.ts`, and index updates in `db/indexes.ts`).
- Added frontend integration: repository client for the new APIs and a `My Games` page with linked-account management, manual PGN paste/upload, stats summary and training-plan UI plus route and navbar entry (`packages/frontend/src/repository/games/games.ts`, `packages/frontend/src/pages/games/GamesPage.tsx`, route wired in `Content.tsx`, navbar entry in `NavbarContainer.tsx`).
- Added tests and docs: unit tests covering PGN splitting/parsing and opening detection (`packages/backend/src/services/test/pgnProcessing.spec.ts`), a feature spec and a user guide (`docs/specs/game-imports-openings-training-plan.md`, `src/doc/Game-Imports-Guide.md`).

### Testing
- Built packages with `yarn build` (common/backend/frontend) and verified TypeScript compilation with `yarn front:tsc:noEmits`, and `webpack` frontend build completed with warnings only. All builds completed successfully.
- Ran lint with `yarn lint` and it completed without new errors for the modified code.
- Ran unit tests: `@chess-opening-master/common` tests passed, `@chess-opening-master/backend` full test suite (including new PGN processing tests) passed locally (`12` backend suites, `120` tests), and `@chess-opening-master/frontend` tests passed; the PGN parsing/detection tests specifically passed.
- Attempted a Playwright-based screenshot of `/games` but the headless Chromium crashed in this environment (SIGSEGV), so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69938de74f148332a329b53e6c8ac5e3)